### PR TITLE
Add optional "intro" to expandable section

### DIFF
--- a/packages/expandable-section/expandable-section.twig
+++ b/packages/expandable-section/expandable-section.twig
@@ -1,4 +1,9 @@
 <div class="expandable-section">
+  {% if intro %}
+    <div class="expandable-section__intro">
+      {{ intro }}
+    </div>
+  {% endif %}
   <button class="expandable-section__expand cta-block cta-block--expand cta-block--expand-to-fit" aria-expanded="false">
     {{ expand_label }}
     <span class="cta-block__icon cta-block__icon--after">

--- a/packages/expandable-section/package.json
+++ b/packages/expandable-section/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/expandable-section",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Provides an expandable section implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/expandable-section/src/scss/styles.scss
+++ b/packages/expandable-section/src/scss/styles.scss
@@ -2,6 +2,10 @@
 
 .expandable-section {
 
+  &__intro {
+    margin-bottom: rem(2);
+  }
+
   &__content {
     overflow: hidden;
     visibility: hidden;

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/_meta/_head.twig
+++ b/packages/patternlab/source/_meta/_head.twig
@@ -9,6 +9,7 @@
     <!-- Begin Pattern Lab (Required for Pattern Lab to run properly) -->
     {{ patternLabHead | raw }}
     <!-- End Pattern Lab -->
+    <link rel="stylesheet" href="../../css/pattern-scaffolding.css?{{ cacheBuster }}" media="all" />
 
     {# @TODO: Move the visually hidden styles into the base component and stop loading hidden.module.css in Drupal #}
     <style>

--- a/packages/patternlab/source/css/pattern-scaffolding.css
+++ b/packages/patternlab/source/css/pattern-scaffolding.css
@@ -1,0 +1,8 @@
+.pl-c-category__description {
+  max-width: unset;
+}
+
+.pl-c-pattern .pl-c-pattern-info {
+  max-height: 45rem;
+  height: auto;
+}

--- a/packages/patternlab/source/patterns/organisms/expandable-section/_expandable-section.md
+++ b/packages/patternlab/source/patterns/organisms/expandable-section/_expandable-section.md
@@ -1,0 +1,11 @@
+---
+title: Expandable Section
+---
+
+### Variables
+| Variable       | Type   | Required | Description                                                        |
+|----------------|--------|----------|--------------------------------------------------------------------|
+| intro          | string | false    | The always-visible content to render before the expanable section. |
+| expand_label   | string | true     | The label to use for the "expand" button.                          |
+| collapse_label | string | true     | The label to use for the "collapse" button.                        |
+| content        | string | true     | The content to progressively display behind the "expand" button.   |

--- a/packages/patternlab/source/patterns/organisms/expandable-section/expandable-section~without-intro.twig
+++ b/packages/patternlab/source/patterns/organisms/expandable-section/expandable-section~without-intro.twig
@@ -1,5 +1,4 @@
 {% include '@organisms/expandable-section/expandable-section.twig' with {
-  intro: "<div class=\"wysiwyg\"><h2 class=\"heading--neutral heading--flush\">Minors</h2><p>Penn State World Campus students can optionally supplement their degree with a minor.</p></div>",
   expand_label: "View Minors",
   content: "<div class=\"grid grid--three-col\"><div class=\"grid__item\" style=\"min-height:10rem;margin:auto;line-height:10rem\"><a href=\"#\">Item 1</a></div><div class=\"grid__item\" style=\"min-height:10rem;margin:auto;line-height:10rem\"><a href=\"#\">Item 2</a></div><div class=\"grid__item\" style=\"min-height:10rem;margin:auto;line-height:10rem\"><a href=\"#\">Item 3</a></div><div class=\"grid__item\" style=\"min-height:10rem;margin:auto;line-height:10rem\"><a href=\"#\">Item 4</a></div><div class=\"grid__item\" style=\"min-height:10rem;margin:auto;line-height:10rem\"><a href=\"#\">Item 5</a></div></div>",
   collapse_label: "Close Minors"


### PR DESCRIPTION
Live Demo: https://developers.outreach.psu.edu/expandable-section-intro/?p=viewall-organisms-expandable-section

Program pages require unique scroll-points for expandable sections.  When a user scrolls to "an expandable section", what the design really calls for is for the scroll point to end up here:

![image](https://user-images.githubusercontent.com/105240977/193584424-6d32fa2a-b06b-4d9a-b914-14f09a330a2f.png)

This means that we have to include the "intro markup" in the component itself.

The proposed change adds an optional "intro" variable to the expandable section component, which may contain arbitrary HTML.  For Layout Builder, we will likely just expose this as a layout region, as follows:

https://www.awesomescreenshot.com/video/11433593?key=57d877f15f1760cf3225fda9fa0fa6bf

---

As a secondary change, I've added some meager documentation and added a bit of CSS to make the Pattern Lab UI a bit more usable when viewing pattern documentation and examples.