### PR TITLE
Add short variant for tabs

### DIFF
--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/tabs-list/tabs-list~short.twig
+++ b/packages/patternlab/source/patterns/molecules/tabs-list/tabs-list~short.twig
@@ -1,0 +1,9 @@
+{% include '@molecules/tabs-list/tabs-list.twig' with {
+  short: true,
+  tabs: [
+    { id: 'tab-1', title: 'Tab 1'},
+    { id: 'tab-2', title: 'Tab 2'},
+    { id: 'tab-3', title: 'Tab 3'},
+    { id: 'tab-4', title: 'Tab 4'},
+  ]
+} only %}

--- a/packages/tabs-list/package.json
+++ b/packages/tabs-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/tabs-list",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Provides a tabs list for use in conjunction with tabs.",
   "publishConfig": {
     "access": "public",

--- a/packages/tabs-list/src/scss/styles.scss
+++ b/packages/tabs-list/src/scss/styles.scss
@@ -43,6 +43,31 @@
     }
   }
 
+  &--short {
+    .tabs-list__button {
+      font-size: rem(1.1);
+      @include bp(xs) {
+        font-size: rem(1.2);
+      }
+
+      @include bp(s) {
+        font-size: rem(1.4);
+      }
+
+      @include bp(m) {
+        font-size: rem(1.5);
+      }
+
+      @include bp(l) {
+        font-size: rem(1.6);
+      }
+
+      @include bp(xl) {
+        font-size: rem(1.6);
+      }
+    }
+  }
+
   &__button {
     /* @TODO: Replace with gap when flex-gap is available. */
     margin-left: rem(.4);
@@ -50,24 +75,31 @@
     padding: rem(.6) 0;
 
     @include bp(xs) {
+      font-size: rem(1.3);
       padding: rem(.8) 0;
     }
 
     @include bp(s) {
+      font-size: rem(1.6);
+      font-weight: 400;
+      letter-spacing: .01em;
       margin-left: rem(.45);
       margin-right: rem(.45);
       padding: rem(1) 0;
     }
 
     @include bp(m) {
+      font-size: rem(1.8);
       padding: rem(1.1) 0;
     }
 
     @include bp(l) {
+      font-size: rem(1.9);
       padding: rem(1.2) 0;
     }
 
     @include bp(xl) {
+      font-size: rem(2.1);
       margin-left: rem(.5);
       margin-right: rem(.5);
       padding: rem(1.3) 0;
@@ -91,28 +123,6 @@
 
     @media screen and (prefers-reduced-motion: no-preference) {
       transition: color .3s linear, box-shadow .3s linear;
-    }
-
-    @include bp(xs) {
-      font-size: rem(1.3);
-    }
-
-    @include bp(s) {
-      font-size: rem(1.6);
-      font-weight: 400;
-      letter-spacing: .01em;
-    }
-
-    @include bp(m) {
-      font-size: rem(1.8);
-    }
-
-    @include bp(l) {
-      font-size: rem(1.9);
-    }
-
-    @include bp(xl) {
-      font-size: rem(2.1);
     }
 
     &[aria-selected="true"] {

--- a/packages/tabs-list/tabs-list.twig
+++ b/packages/tabs-list/tabs-list.twig
@@ -7,6 +7,9 @@
 {% if borderless_inactive %}
   {% set classes = classes|merge(['tabs-list--borderless-inactive']) %}
 {% endif %}
+{% if short %}
+  {% set classes = classes|merge(['tabs-list--short']) %}
+{% endif %}
 <div class="{{ classes|join(' ') }}" role="tablist" data-flex-wrap-aware>
   {% for tab in tabs %}
     <button class="tabs-list__button"


### PR DESCRIPTION
This adds a feature: `tabs-list--short` for situations where we want shorter tabs.
![image](https://user-images.githubusercontent.com/105240977/195421638-07ad495f-dc86-4ca6-9a20-3467b1bc9bda.png)
