### PR TITLE
Implement a "highlighted text" component

### DIFF
--- a/packages/highlighted-text/highlighted-text.twig
+++ b/packages/highlighted-text/highlighted-text.twig
@@ -5,10 +5,10 @@
 {% if color %}
   {% set classes = classes|merge(['highlighted-text--' ~ color]) %}
 {% endif %}
+{% apply spaceless %}
 <div class="{{ classes|join(' ') }}">
   <span class="highlighted-text__highlight">
-    <span class="highlighted-text__relative">
-      {{ content }}
-    </span>
+    <span class="highlighted-text__relative">{{ content }}</span>
   </span>
 </div>
+{% endapply %}

--- a/packages/highlighted-text/highlighted-text.twig
+++ b/packages/highlighted-text/highlighted-text.twig
@@ -1,0 +1,14 @@
+{% set classes = ['highlighted-text'] %}
+{% if size %}
+  {% set classes = classes|merge(['highlighted-text--' ~ size]) %}
+{% endif %}
+{% if color %}
+  {% set classes = classes|merge(['highlighted-text--' ~ color]) %}
+{% endif %}
+<div class="{{ classes|join(' ') }}">
+  <span class="highlighted-text__highlight">
+    <span class="highlighted-text__relative">
+      {{ content }}
+    </span>
+  </span>
+</div>

--- a/packages/highlighted-text/package.json
+++ b/packages/highlighted-text/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@psu-ooe/highlighted-text",
+  "version": "1.0.0",
+  "description": "Provides on-brand text highlighting capabilities.",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "dependencies": {
+    "@psu-ooe/base": "^1.0"
+  }
+}

--- a/packages/highlighted-text/src/scss/styles.scss
+++ b/packages/highlighted-text/src/scss/styles.scss
@@ -5,6 +5,7 @@
   color: $white;
   font-family: $open-sans;
   padding: 1rem 0;
+  margin: 0;
 
   &__highlight {
     padding: rem(1) 0;

--- a/packages/highlighted-text/src/scss/styles.scss
+++ b/packages/highlighted-text/src/scss/styles.scss
@@ -8,7 +8,8 @@
   margin: 0;
 
   &__highlight {
-    padding: rem(1) 0;
+    padding: rem(1) rem(1.5);
+    margin: 0 rem(-1.5);
     box-decoration-break: clone;
     -webkit-box-decoration-break: clone;
   }
@@ -20,14 +21,12 @@
   &--primary-blue {
     .highlighted-text__highlight {
       background-color: $primary-blue;
-      box-shadow: rem(1.5) 0 0 $primary-blue, rem(-1.5) 0 0 $primary-blue;
     }
   }
 
   &--beaver-blue {
     .highlighted-text__highlight {
       background-color: $beaver-blue;
-      box-shadow: rem(1.5) 0 0 $beaver-blue, rem(-1.5) 0 0 $beaver-blue;
     }
   }
 
@@ -52,7 +51,7 @@
       margin-top: rem(.125);
 
       @include bp(xs) {
-        margin-top: rem(-.2);
+        margin-top: rem(-.205);
       }
 
       @include bp(xl) {

--- a/packages/highlighted-text/src/scss/styles.scss
+++ b/packages/highlighted-text/src/scss/styles.scss
@@ -1,0 +1,61 @@
+@import "../../../base/src/scss/imports/variables";
+@import "../../../base/src/scss/imports/layout";
+
+.highlighted-text {
+  color: $white;
+  font-family: $open-sans;
+  padding: 1rem 0;
+
+  &__highlight {
+    padding: 1rem 1.5rem;
+    -webkit-box-decoration-break: clone;
+  }
+
+  &__relative {
+    position: relative;
+  }
+
+  &--primary-blue {
+    .highlighted-text__highlight {
+      background-color: $primary-blue;
+    }
+  }
+
+  &--beaver-blue {
+    .highlighted-text__highlight {
+      background-color: $beaver-blue;
+    }
+  }
+
+  &--large {
+    font-weight: bold;
+    font-size: rem(2.6);
+    line-height: calc(3.2 / 2.6);
+
+    @include bp(xs) {
+      font-size: rem(3);
+      line-height: calc(4.2 / 3);
+    }
+
+    @include bp(xl) {
+      font-size: rem(3.6);
+      line-height: calc(4.9 / 3.6);
+    }
+  }
+
+  &--small {
+    font-size: rem(1.5);
+    line-height: calc(2 / 1.5);
+
+    @include bp(xs) {
+      font-size: rem(1.8);
+      line-height: calc(2.4 / 1.8);
+    }
+
+    @include bp(xl) {
+      font-size: rem(1.9);
+      line-height: calc(2.6 / 1.9);
+    }
+
+  }
+}

--- a/packages/highlighted-text/src/scss/styles.scss
+++ b/packages/highlighted-text/src/scss/styles.scss
@@ -64,6 +64,7 @@
   &--small {
     font-size: rem(1.5);
     font-weight: 600;
+    letter-spacing: normal;
     line-height: calc(2 / 1.5);
 
     @include bp(xs) {

--- a/packages/highlighted-text/src/scss/styles.scss
+++ b/packages/highlighted-text/src/scss/styles.scss
@@ -28,8 +28,9 @@
   }
 
   &--large {
-    font-weight: bold;
+    font-weight: 700;
     font-size: rem(2.6);
+    letter-spacing: -0.01467em;
     line-height: calc(3.2 / 2.6);
 
     @include bp(xs) {
@@ -45,6 +46,7 @@
 
   &--small {
     font-size: rem(1.5);
+    font-weight: 600;
     line-height: calc(2 / 1.5);
 
     @include bp(xs) {

--- a/packages/highlighted-text/src/scss/styles.scss
+++ b/packages/highlighted-text/src/scss/styles.scss
@@ -81,7 +81,7 @@
       margin-top: rem(.125);
 
       @include bp(xs) {
-        margin-top: rem(-.025);
+        margin-top: rem(-.03);
       }
     }
   }

--- a/packages/highlighted-text/src/scss/styles.scss
+++ b/packages/highlighted-text/src/scss/styles.scss
@@ -7,7 +7,8 @@
   padding: 1rem 0;
 
   &__highlight {
-    padding: 1rem 1.5rem;
+    padding: rem(1) 0;
+    box-decoration-break: clone;
     -webkit-box-decoration-break: clone;
   }
 
@@ -18,12 +19,14 @@
   &--primary-blue {
     .highlighted-text__highlight {
       background-color: $primary-blue;
+      box-shadow: rem(1.5) 0 0 $primary-blue, rem(-1.5) 0 0 $primary-blue;
     }
   }
 
   &--beaver-blue {
     .highlighted-text__highlight {
       background-color: $beaver-blue;
+      box-shadow: rem(1.5) 0 0 $beaver-blue, rem(-1.5) 0 0 $beaver-blue;
     }
   }
 
@@ -42,6 +45,19 @@
       font-size: rem(3.6);
       line-height: calc(4.9 / 3.6);
     }
+
+    // Correct minor overlap errors at certain viewport dimensions.
+    & + .highlighted-text--small {
+      margin-top: rem(.2);
+
+      @include bp(xs) {
+        margin-top: rem(-.1);
+      }
+
+      @include bp(xl) {
+        margin-top: 0;
+      }
+    }
   }
 
   &--small {
@@ -59,5 +75,13 @@
       line-height: calc(2.6 / 1.9);
     }
 
+    // Correct minor overlap errors at certain viewport dimensions.
+    & + .highlighted-text--large {
+      margin-top: rem(.2);
+
+      @include bp(xs) {
+        margin-top: 0;
+      }
+    }
   }
 }

--- a/packages/highlighted-text/src/scss/styles.scss
+++ b/packages/highlighted-text/src/scss/styles.scss
@@ -4,7 +4,7 @@
 .highlighted-text {
   color: $white;
   font-family: $open-sans;
-  padding: 1rem 0;
+  padding: rem(1) 0;
   margin: 0;
 
   &__highlight {

--- a/packages/highlighted-text/src/scss/styles.scss
+++ b/packages/highlighted-text/src/scss/styles.scss
@@ -49,10 +49,10 @@
 
     // Correct minor overlap errors at certain viewport dimensions.
     & + .highlighted-text--small {
-      margin-top: rem(.2);
+      margin-top: rem(.125);
 
       @include bp(xs) {
-        margin-top: rem(-.1);
+        margin-top: rem(-.2);
       }
 
       @include bp(xl) {
@@ -79,10 +79,10 @@
 
     // Correct minor overlap errors at certain viewport dimensions.
     & + .highlighted-text--large {
-      margin-top: rem(.2);
+      margin-top: rem(.125);
 
       @include bp(xs) {
-        margin-top: 0;
+        margin-top: rem(-.025);
       }
     }
   }

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"
@@ -24,6 +24,7 @@
     "@psu-ooe/flex-wrap-listener": "^1.0",
     "@psu-ooe/grid": "^1.0",
     "@psu-ooe/heading": "^1.0",
+    "@psu-ooe/highlighted-text": "^1.0",
     "@psu-ooe/intro-form": "^1.0",
     "@psu-ooe/overlay": "^1.0",
     "@psu-ooe/parallel-navigation": "^1.0",

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~large-beaver-blue.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~large-beaver-blue.twig
@@ -1,5 +1,8 @@
-{% include '@molecules/highlighted-text/highlighted-text.twig' with {
-  content: 'Testing a really long heading that probably happens a lot more often than it really should',
-  size: 'large',
-  color: 'beaver-blue',
-} only %}
+<div style="padding:0 2rem;">
+  {% include '@molecules/highlighted-text/highlighted-text.twig' with {
+    content: 'Testing a really long heading that probably happens a lot more often than it really should',
+    size: 'large',
+    color: 'beaver-blue',
+  } only %}
+  <p>Some text under the highlight</p>
+</div>

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~large-beaver-blue.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~large-beaver-blue.twig
@@ -1,0 +1,5 @@
+{% include '@molecules/highlighted-text/highlighted-text.twig' with {
+  content: 'Testing a really long heading that probably happens a lot more often than it really should',
+  size: 'large',
+  color: 'beaver-blue',
+} only %}

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~large-primary-blue.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~large-primary-blue.twig
@@ -1,0 +1,5 @@
+{% include '@molecules/highlighted-text/highlighted-text.twig' with {
+  content: 'Testing a really long heading that probably happens a lot more often than it really should',
+  size: 'large',
+  color: 'primary-blue',
+} only %}

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~large-primary-blue.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~large-primary-blue.twig
@@ -1,5 +1,8 @@
-{% include '@molecules/highlighted-text/highlighted-text.twig' with {
-  content: 'Testing a really long heading that probably happens a lot more often than it really should',
-  size: 'large',
-  color: 'primary-blue',
-} only %}
+<div style="padding:0 2rem;">
+  {% include '@molecules/highlighted-text/highlighted-text.twig' with {
+    content: 'Testing a really long heading that probably happens a lot more often than it really should',
+    size: 'large',
+    color: 'primary-blue',
+  } only %}
+  <p>Some text under the highlight</p>
+</div>

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~small-beaver-blue.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~small-beaver-blue.twig
@@ -1,0 +1,5 @@
+{% include '@molecules/highlighted-text/highlighted-text.twig' with {
+  content: 'Testing a really long heading that probably happens a lot more often than it really should',
+  size: 'small',
+  color: 'beaver-blue',
+} only %}

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~small-beaver-blue.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~small-beaver-blue.twig
@@ -1,5 +1,8 @@
-{% include '@molecules/highlighted-text/highlighted-text.twig' with {
-  content: 'Testing a really long heading that probably happens a lot more often than it really should',
-  size: 'small',
-  color: 'beaver-blue',
-} only %}
+<div style="padding:0 2rem;">
+  {% include '@molecules/highlighted-text/highlighted-text.twig' with {
+    content: 'Testing a really long heading that probably happens a lot more often than it really should',
+    size: 'small',
+    color: 'beaver-blue',
+  } only %}
+  <p>Some text under the highlight</p>
+</div>

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~small-primary-blue.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~small-primary-blue.twig
@@ -1,0 +1,5 @@
+{% include '@molecules/highlighted-text/highlighted-text.twig' with {
+  content: 'Testing a really long heading that probably happens a lot more often than it really should',
+  size: 'small',
+  color: 'primary-blue',
+} only %}

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~small-primary-blue.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~small-primary-blue.twig
@@ -1,5 +1,8 @@
-{% include '@molecules/highlighted-text/highlighted-text.twig' with {
-  content: 'Testing a really long heading that probably happens a lot more often than it really should',
-  size: 'small',
-  color: 'primary-blue',
-} only %}
+<div style="padding:0 2rem;">
+  {% include '@molecules/highlighted-text/highlighted-text.twig' with {
+    content: 'Testing a really long heading that probably happens a lot more often than it really should',
+    size: 'small',
+    color: 'primary-blue',
+  } only %}
+  <p>Some text under the highlight</p>
+</div>

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~stacked-2.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~stacked-2.twig
@@ -1,0 +1,12 @@
+{% apply spaceless %}
+  {% include '@molecules/highlighted-text/highlighted-text.twig' with {
+    content: 'Master of',
+    size: 'small',
+    color: 'beaver-blue',
+  } only %}
+  {% include '@molecules/highlighted-text/highlighted-text.twig' with {
+    content: 'Testing Design Systems',
+    size: 'large',
+    color: 'primary-blue',
+  } only %}
+{% endapply %}

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~stacked-2.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~stacked-2.twig
@@ -1,4 +1,4 @@
-{% apply spaceless %}
+<div style="padding:0 2rem;">
   {% include '@molecules/highlighted-text/highlighted-text.twig' with {
     content: 'Master of',
     size: 'small',
@@ -9,4 +9,6 @@
     size: 'large',
     color: 'primary-blue',
   } only %}
-{% endapply %}
+  <p>Some text under the highlight</p>
+</div>
+

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~stacked.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~stacked.twig
@@ -1,4 +1,4 @@
-{% apply spaceless %}
+<div style="padding:0 2rem;">
   {% include '@molecules/highlighted-text/highlighted-text.twig' with {
     content: 'Testing',
     size: 'large',
@@ -9,4 +9,6 @@
     size: 'small',
     color: 'beaver-blue',
   } only %}
-{% endapply %}
+  <p>Some text under the highlight</p>
+</div>
+

--- a/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~stacked.twig
+++ b/packages/patternlab/source/patterns/molecules/highlighted-text/highlighted-text~stacked.twig
@@ -1,0 +1,12 @@
+{% apply spaceless %}
+  {% include '@molecules/highlighted-text/highlighted-text.twig' with {
+    content: 'Testing',
+    size: 'large',
+    color: 'primary-blue',
+  } only %}
+  {% include '@molecules/highlighted-text/highlighted-text.twig' with {
+    content: 'Online Degree and Certificate Programs',
+    size: 'small',
+    color: 'beaver-blue',
+  } only %}
+{% endapply %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,6 +1616,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@psu-ooe/highlighted-text@workspace:packages/highlighted-text":
+  version: 0.0.0-use.local
+  resolution: "@psu-ooe/highlighted-text@workspace:packages/highlighted-text"
+  dependencies:
+    "@psu-ooe/base": ^1.0
+  languageName: unknown
+  linkType: soft
+
 "@psu-ooe/intro-form@^1.0, @psu-ooe/intro-form@workspace:packages/intro-form":
   version: 0.0.0-use.local
   resolution: "@psu-ooe/intro-form@workspace:packages/intro-form"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,7 +1616,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@psu-ooe/highlighted-text@workspace:packages/highlighted-text":
+"@psu-ooe/highlighted-text@^1.0, @psu-ooe/highlighted-text@workspace:packages/highlighted-text":
   version: 0.0.0-use.local
   resolution: "@psu-ooe/highlighted-text@workspace:packages/highlighted-text"
   dependencies:
@@ -1695,6 +1695,7 @@ __metadata:
     "@psu-ooe/flex-wrap-listener": ^1.0
     "@psu-ooe/grid": ^1.0
     "@psu-ooe/heading": ^1.0
+    "@psu-ooe/highlighted-text": ^1.0
     "@psu-ooe/intro-form": ^1.0
     "@psu-ooe/overlay": ^1.0
     "@psu-ooe/parallel-navigation": ^1.0


### PR DESCRIPTION
We should be able to replace all of the random styles / markup for all of our different page title things with this.

Right now, roll-outscope is limited to the new program page project, but the expectation is that it replaces highlighted text everywhere eventually.