### PR TITLE
Add new 'hr' variant (currently existeds on the prospect site)

### DIFF
--- a/packages/heading/heading.twig
+++ b/packages/heading/heading.twig
@@ -4,7 +4,7 @@
 
 {% set allowed_levels = 1..6 %}
 {% set allowed_colors = ['neutral']  %}
-{% set allowed_sizes = ['xlarge', 'large', 'medium', 'small', 'xsmall'] %}
+{% set allowed_sizes = ['xlarge', 'large', 'medium', 'small', 'xsmall', 'hr'] %}
 
 {% if level in allowed_levels and content is not empty %}
 

--- a/packages/heading/heading.twig
+++ b/packages/heading/heading.twig
@@ -2,16 +2,21 @@
 {% set level = level|default(2) %}
 {% set flush = flush|default(false) %}
 
+{# @deprecated: Remove 'size' in 2.0 #}
+{% if size and not style %}
+  {% set style = size %}
+{% endif %}
+
 {% set allowed_levels = 1..6 %}
 {% set allowed_colors = ['neutral']  %}
-{% set allowed_sizes = ['xlarge', 'large', 'medium', 'small', 'xsmall', 'hr'] %}
+{% set allowed_styles = ['xlarge', 'large', 'medium', 'small', 'xsmall', 'hr'] %}
 
 {% if level in allowed_levels and content is not empty %}
 
   {% set classes = classes|merge([
     'heading',
     color in allowed_colors ? 'heading--' ~ color,
-    size in allowed_sizes ? 'heading--' ~ size,
+    style in allowed_styles ? 'heading--' ~ style,
     flush ? 'heading--flush',
   ]) | filter(class => class is not empty) %}
 {% apply spaceless %}

--- a/packages/heading/package.json
+++ b/packages/heading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/heading",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Provides a heading implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/atoms/heading/_heading.md
+++ b/packages/patternlab/source/patterns/atoms/heading/_heading.md
@@ -11,13 +11,14 @@ title: Headings
 | color    | string  | false    | Must match a documented color modifier (below).                             |
 
 ## Size modifiers
-| Size   | Description                         |
-| ------ | ----------------------------------- |
-| xlarge | This style looks like an &lt;h1&gt; |
-| large  | This style looks like an &lt;h2&gt; |
-| medium | This style looks like an &lt;h3&gt; |
-| small  | This style looks like an &lt;h4&gt; |
-| xsmall | This style looks like an &lt;h5&gt; |
+| Size   | Description                                                       |
+|--------|-------------------------------------------------------------------|
+| xlarge | This style looks like an &lt;h1&gt;                               |
+| large  | This style looks like an &lt;h2&gt;                               |
+| medium | This style looks like an &lt;h3&gt;                               |
+| small  | This style looks like an &lt;h4&gt;                               |
+| xsmall | This style looks like an &lt;h5&gt;                               |
+| hr     | This style renders the heading in a horizontal-rule-like fashion. |
 
 ## Color modifiers
 | Color    | Description                                           |

--- a/packages/patternlab/source/patterns/atoms/heading/_heading.md
+++ b/packages/patternlab/source/patterns/atoms/heading/_heading.md
@@ -4,13 +4,14 @@ title: Headings
 ---
 # Variables
 | Variable | Type    | Required | Description                                                                 |
-| -------- | ------- | -------- | --------------------------------------------------------------------------- |
+|----------|---------|----------|-----------------------------------------------------------------------------|
 | content  | string  | true     | The content to render within the heading.                                   |
 | level    | integer | false    | An integer, between 1 and 6 that denotes the heading level.  Defaults to 2. |
-| size     | string  | false    | Must match a documented size modifier (below).                              |
+| size     | string  | false    | **DEPRECATED: Use "style" instead.**                                        |
+| style    | string  | false    | Must match a documented style modifier (below).                             |
 | color    | string  | false    | Must match a documented color modifier (below).                             |
 
-## Size modifiers
+## Style modifiers
 | Size   | Description                                                       |
 |--------|-------------------------------------------------------------------|
 | xlarge | This style looks like an &lt;h1&gt;                               |
@@ -21,11 +22,11 @@ title: Headings
 | hr     | This style renders the heading in a horizontal-rule-like fashion. |
 
 ## Color modifiers
-| Color    | Description                                           |
-| -------- | ----------------------------------------------------- |
-| neutral  | If specified, the color of the heading becomes Slate. |
+| Color   | Description                                           |
+|---------|-------------------------------------------------------|
+| neutral | If specified, the color of the heading becomes Slate. |
 
 ## Position modifiers
 | Modifier | Description                                                                                 |
-| -------- | ------------------------------------------------------------------------------------------- |
+|----------|---------------------------------------------------------------------------------------------|
 | flush    | If specified, the heading will be shifted up to avoid extra space in the upper line-height. |

--- a/packages/patternlab/source/patterns/atoms/heading/heading~1-neutral.twig
+++ b/packages/patternlab/source/patterns/atoms/heading/heading~1-neutral.twig
@@ -2,5 +2,5 @@
   level: 1,
   content: "The quick brown fox <span class=\"text--contrasting\">jumps</span> over the lazy dog",
   color: "neutral",
-  size: "xlarge"
+  style: "xlarge"
 } only %}

--- a/packages/patternlab/source/patterns/atoms/heading/heading~2-neutral.twig
+++ b/packages/patternlab/source/patterns/atoms/heading/heading~2-neutral.twig
@@ -2,5 +2,5 @@
   level: 2,
   content: "The quick brown fox <span class=\"text--contrasting\">jumps</span> over the lazy dog",
   color: "neutral",
-  size: "large"
+  style: "large"
 } only %}

--- a/packages/patternlab/source/patterns/atoms/heading/heading~3-neutral.twig
+++ b/packages/patternlab/source/patterns/atoms/heading/heading~3-neutral.twig
@@ -2,5 +2,5 @@
   level: 3,
   content: "The quick brown fox <span class=\"text--contrasting\">jumps</span> over the lazy dog",
   color: "neutral",
-  size: "medium"
+  style: "medium"
 } only %}

--- a/packages/patternlab/source/patterns/atoms/heading/heading~4-neutral.twig
+++ b/packages/patternlab/source/patterns/atoms/heading/heading~4-neutral.twig
@@ -2,5 +2,5 @@
   level: 4,
   content: "The quick brown fox <span class=\"text--contrasting\">jumps</span> over the lazy dog",
   color: "neutral",
-  size: "small"
+  style: "small"
 } only %}

--- a/packages/patternlab/source/patterns/atoms/heading/heading~5-neutral.twig
+++ b/packages/patternlab/source/patterns/atoms/heading/heading~5-neutral.twig
@@ -2,5 +2,5 @@
   level: 5,
   content: "The quick brown fox <span class=\"text--contrasting\">jumps</span> over the lazy dog",
   color: "neutral",
-  size: "xsmall"
+  style: "xsmall"
 } only %}

--- a/packages/patternlab/source/patterns/atoms/heading/heading~hr.twig
+++ b/packages/patternlab/source/patterns/atoms/heading/heading~hr.twig
@@ -1,0 +1,4 @@
+{% include '@atoms/heading/heading.twig' with {
+  content: "The quick brown fox jumps over the lazy dog",
+  size: "hr"
+} only %}

--- a/packages/patternlab/source/patterns/atoms/heading/heading~hr.twig
+++ b/packages/patternlab/source/patterns/atoms/heading/heading~hr.twig
@@ -1,4 +1,4 @@
 {% include '@atoms/heading/heading.twig' with {
   content: "The quick brown fox jumps over the lazy dog",
-  size: "hr"
+  style: "hr"
 } only %}


### PR DESCRIPTION
- [x] Deprecate "size" variable, replaced with "style", which is more accurate to what it represents.
- [x] Add 'hr' variant for headings (homepage on prospect site representation).