### PR TITLE
Add new dropbutton variant...deprecate an old one.

### DIFF
--- a/packages/drop-button/drop-button.twig
+++ b/packages/drop-button/drop-button.twig
@@ -1,6 +1,10 @@
 {% set classes = ['drop-button'] %}
+{# @deprecated - short to be removed in 2.0.0 #}
 {% if short %}
     {% set classes = classes|merge(['drop-button--short']) %}
+{% endif %}
+{% if sticky_tab %}
+  {% set classes = classes|merge(['drop-button--sticky-tab']) %}
 {% endif %}
 {% if full_width %}
     {%  set classes = classes|merge(['drop-button--full-width']) %}
@@ -10,7 +14,11 @@
 {% endif %}
 <div class="{{ classes|join(' ' ) }}">
     <button class="drop-button__toggle" aria-expanded="false">
-      {% include '@atoms/sprite/sprite.twig' with { name: short ? 'fas-ellipsis-vertical' : 'fas-ellipsis' } only %}
+      {% if short or sticky_tab %}
+        {% include '@atoms/sprite/sprite.twig' with { name: 'fas-ellipsis-vertical' } only %}
+      {% else %}
+        {% include '@atoms/sprite/sprite.twig' with { name: 'fas-ellipsis' } only %}
+      {% endif %}
       <span class="drop-button__label">{{ button_label }}</span>
     </button>
     <ul class="drop-button__list">

--- a/packages/drop-button/package.json
+++ b/packages/drop-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/drop-button",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "An accessible drop-button component.",
   "ooe": {
     "namespace": "global"

--- a/packages/drop-button/src/scss/styles.scss
+++ b/packages/drop-button/src/scss/styles.scss
@@ -142,7 +142,6 @@
     border-width: rem(.1) rem(.1) rem(.1) rem(.3);
     box-shadow: rem(.1) rem(.3) rem(.5) rgba($nittany-navy, .15);
     padding: rem(1);
-    max-width: 100%;
     width: rem(28);
     z-index: 100;
     top: 100%;
@@ -249,6 +248,7 @@
     }
   }
 
+  // @deprecated - to be removed in 2.0.0
   &--short {
 
     .drop-button__toggle {
@@ -308,6 +308,32 @@
 
       &__list {
         width: 100%;
+      }
+    }
+  }
+
+  &--sticky-tab {
+    .drop-button {
+      &__toggle {
+        flex-direction: row;
+        justify-content: space-around;
+        width: auto;
+        height: auto;
+        min-height: 100%;
+        padding: rem(1) rem(1.5);
+
+        .sprite {
+          height: rem(1.4);
+          width: auto;
+        }
+      }
+
+      &__label {
+        font-size: rem(1.1);
+      }
+
+      &__list::before {
+        right: calc(#{rem(3.2845)} - #{rem(math.div(math.sqrt(200), 10))});
       }
     }
   }

--- a/packages/drop-button/src/scss/styles.scss
+++ b/packages/drop-button/src/scss/styles.scss
@@ -331,7 +331,7 @@
 
       &__label {
         font-size: rem(1.1);
-        margin-bottom: rem(.1);
+        font-weight: 600;
       }
 
       &__list::before {

--- a/packages/drop-button/src/scss/styles.scss
+++ b/packages/drop-button/src/scss/styles.scss
@@ -325,11 +325,13 @@
         .sprite {
           height: rem(1.4);
           width: auto;
+          margin-top: 0;
         }
       }
 
       &__label {
         font-size: rem(1.1);
+        margin-bottom: rem(.1);
       }
 
       &__list::before {

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/drop-button/drop-button~short.twig
+++ b/packages/patternlab/source/patterns/molecules/drop-button/drop-button~short.twig
@@ -1,3 +1,4 @@
+<strong>This pattern is deprecated and will be removed in 2.0.0!</strong>
 {% include '@molecules/drop-button/drop-button.twig' with {
     button_label: '<span class="visually-hidden">4</span> More <span class="visually-hidden">options</span>',
     links: [

--- a/packages/patternlab/source/patterns/molecules/drop-button/drop-button~sticky-tab.twig
+++ b/packages/patternlab/source/patterns/molecules/drop-button/drop-button~sticky-tab.twig
@@ -1,0 +1,13 @@
+<div style="display:flex;align-items:stretch; min-height: 4rem;justify-content:flex-end;">
+  {% include '@molecules/drop-button/drop-button.twig' with {
+    button_label: '<span class="visually-hidden">4</span> More <span class="visually-hidden">options</span>',
+    links: [
+      { "url": "#", "label": "Item 1"},
+      { "url": "#", "label": "Item 2"},
+      { "url": "#", "label": "Item 3"},
+      { "url": "#", "label": "Item 4"},
+    ],
+    sticky_tab: true,
+    align: 'right',
+  } only %}
+</div>


### PR DESCRIPTION
Looks like our general-purpose drop-button component couldn't be used on program pages after all.

I'm not sure how I feel about this in general.  Seems like a very hacky thing to plumb into a design system (a variant that's used in one specific place).

See https://developers.outreach.psu.edu/new-dropbutton-variant/?p=viewall-molecules-drop-button

The new variant...

1. Has consistent width and height behaviors across all viewports.
2. Expands to take up its container's height.
3. Has a different font weight
4. Has a different sprite size

We also had to remove the `max-width: 100%`, as it was causing issues when put inside of a `tabs-list`.  The only relative danger here is for viewports < 280px wide, which we don't support anyway.