### PR TITLE
Add customizable heading level and random image functionality to the `intro-form` component.

### DIFF
--- a/packages/intro-form/intro-form.twig
+++ b/packages/intro-form/intro-form.twig
@@ -1,13 +1,28 @@
+{% if heading_level not in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] %}
+  {% set heading_level = 'span' %}
+{% endif %}
+
+{# @deprecated - the 'image' variable is removed in 2.0.0, use 'images' instead #}
+{% if image and not images %}
+ {% set images = [image] %}
+{% endif %}
+
 <div class="intro-form">
   <div class="intro-form__container">
     <div class="intro-form__first">
       <div class="intro-form__border"></div>
-      <div class="intro-form__image">{{ image }}</div>
+      <div class="intro-form__image">
+        {% if images|length > 1 %}
+          {% include '@molecules/random-item/random-item.twig' with { items: images } only %}
+        {% else %}
+          {{ images[0] }}
+        {% endif %}
+      </div>
       <div class="intro-form__intro">
         <div class="intro-form__overlay">
-          <span class="intro-form__title">
+          <{{ heading_level}} class="intro-form__title">
             <span class="intro-form__relative">{{ title }}</span>
-          </span>
+          </{{ heading_level }}>
         </div>
         <p class="intro-form__description">{{ description }}</p>
       </div>

--- a/packages/intro-form/intro-form.twig
+++ b/packages/intro-form/intro-form.twig
@@ -20,7 +20,7 @@
       </div>
       <div class="intro-form__intro">
         <div class="intro-form__overlay">
-          <{{ heading_level}} class="intro-form__title">
+          <{{ heading_level }} class="intro-form__title">
             <span class="intro-form__relative">{{ title }}</span>
           </{{ heading_level }}>
         </div>

--- a/packages/intro-form/package.json
+++ b/packages/intro-form/package.json
@@ -7,6 +7,7 @@
     "registry": "https://npm.pkg.github.com/"
   },
   "dependencies": {
-    "@psu-ooe/base": "^1.0"
+    "@psu-ooe/base": "^1.0",
+    '@psu-ooe/random-item': "^1.0"
   }
 }

--- a/packages/intro-form/package.json
+++ b/packages/intro-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/intro-form",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Provides a specialized container for presenting a form with accompanying intro content.",
   "publishConfig": {
     "access": "public",

--- a/packages/intro-form/package.json
+++ b/packages/intro-form/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "@psu-ooe/base": "^1.0",
-    '@psu-ooe/random-item': "^1.0"
+    "@psu-ooe/random-item": "^1.0"
   }
 }

--- a/packages/intro-form/src/scss/styles.scss
+++ b/packages/intro-form/src/scss/styles.scss
@@ -41,7 +41,14 @@
   }
 
   &__image {
+    background-color: $white;
     position: absolute;
+    aspect-ratio: 16/7;
+    width: 100%;
+
+    @include bp(s) {
+      aspect-ratio: 2;
+    }
 
     img {
       aspect-ratio: 16/7;

--- a/packages/intro-form/src/scss/styles.scss
+++ b/packages/intro-form/src/scss/styles.scss
@@ -83,11 +83,14 @@
   }
 
   &__title {
+    display: inline;
+    letter-spacing: normal;
     position: relative;
     font-size: rem(3.4);
     font-family: $open-sans;
     background: $primary-blue;
     padding: rem(1) rem(1.5);
+    margin: 0;
     box-decoration-break: clone;
     -webkit-box-decoration-break: clone;
     color: $white;

--- a/packages/patternlab/source/patterns/molecules/intro-form/intro-form.twig
+++ b/packages/patternlab/source/patterns/molecules/intro-form/intro-form.twig
@@ -1,7 +1,7 @@
 {# @TODO: Replace with a real form when base styles allow... #}
 {% include '@molecules/intro-form/intro-form.twig' with {
   "images": [
-    "<img src=\"https://via.placeholder.com/800x350\" alt=\"800 by 350 gray placeholder\">",
+    "<img src=\"https://via.placeholder.com/800x350\" alt=\"\">",
   ],
   "title": "Ready to Learn More?",
   "description": "Get the resources you need to make informed decisions about your education. Request information on this program and other programs of interest by completing this form.",

--- a/packages/patternlab/source/patterns/molecules/intro-form/intro-form~imageless.twig
+++ b/packages/patternlab/source/patterns/molecules/intro-form/intro-form~imageless.twig
@@ -1,0 +1,6 @@
+{# @TODO: Replace with a real form when base styles allow... #}
+{% include '@molecules/intro-form/intro-form.twig' with {
+  "title": "Ready to Learn More?",
+  "description": "Get the resources you need to make informed decisions about your education. Request information on this program and other programs of interest by completing this form.",
+  "form": "Form placeholder"
+} only %}

--- a/packages/patternlab/source/patterns/molecules/intro-form/intro-form~random-images.twig
+++ b/packages/patternlab/source/patterns/molecules/intro-form/intro-form~random-images.twig
@@ -1,9 +1,12 @@
 {# @TODO: Replace with a real form when base styles allow... #}
 {% include '@molecules/intro-form/intro-form.twig' with {
+  "heading_level": "h2",
+  "title": "Ready to Learn More?",
   "images": [
     "<img src=\"https://via.placeholder.com/800x350\" alt=\"800 by 350 gray placeholder\">",
+    "<img src=\"https://via.placeholder.com/1600x700\" alt=\"1600 by 700 gray placeholder\">",
+    "<img src=\"https://via.placeholder.com/3200x1400\" alt=\"3200 by 1400 gray placeholder\">",
   ],
-  "title": "Ready to Learn More?",
   "description": "Get the resources you need to make informed decisions about your education. Request information on this program and other programs of interest by completing this form.",
   "form": "Form placeholder"
 } only %}

--- a/packages/patternlab/source/patterns/molecules/intro-form/intro-form~random-images.twig
+++ b/packages/patternlab/source/patterns/molecules/intro-form/intro-form~random-images.twig
@@ -3,9 +3,9 @@
   "heading_level": "h2",
   "title": "Ready to Learn More?",
   "images": [
-    "<img src=\"https://via.placeholder.com/800x350\" alt=\"800 by 350 gray placeholder\">",
-    "<img src=\"https://via.placeholder.com/1600x700\" alt=\"1600 by 700 gray placeholder\">",
-    "<img src=\"https://via.placeholder.com/3200x1400\" alt=\"3200 by 1400 gray placeholder\">",
+    "<img src=\"https://via.placeholder.com/800x350\" alt=\"\">",
+    "<img src=\"https://via.placeholder.com/1600x700\" alt=\"\">",
+    "<img src=\"https://via.placeholder.com/3200x1400\" alt=\"\">",
   ],
   "description": "Get the resources you need to make informed decisions about your education. Request information on this program and other programs of interest by completing this form.",
   "form": "Form placeholder"

--- a/packages/patternlab/source/patterns/organisms/random-item/random-item.twig
+++ b/packages/patternlab/source/patterns/organisms/random-item/random-item.twig
@@ -1,0 +1,2 @@
+{% set items = ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5'] %}
+{% include '@organisms/random-item/random-item.twig' with { items: items } only %}

--- a/packages/random-item/package.json
+++ b/packages/random-item/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@psu-ooe/random-item",
+  "version": "1.0.0",
+  "description": "Provides a simple client-side randomization mechanism.",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com/"
+  }
+}

--- a/packages/random-item/random-item.twig
+++ b/packages/random-item/random-item.twig
@@ -1,0 +1,10 @@
+<div class="random-item">
+  <script>
+    (() => {
+      const items = {{ items|json_encode()|raw }};
+      if (items) {
+        document.currentScript.parentElement.outerHTML = items[~~(Math.random() * items.length)];
+      }
+    })();
+  </script>
+</div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1629,6 +1629,7 @@ __metadata:
   resolution: "@psu-ooe/intro-form@workspace:packages/intro-form"
   dependencies:
     "@psu-ooe/base": ^1.0
+    "@psu-ooe/random-item": ^1.0
   languageName: unknown
   linkType: soft
 
@@ -1735,6 +1736,12 @@ __metadata:
   resolution: "@psu-ooe/quote@workspace:packages/quote"
   dependencies:
     "@psu-ooe/base": ^1.0
+  languageName: unknown
+  linkType: soft
+
+"@psu-ooe/random-item@^1.0, @psu-ooe/random-item@workspace:packages/random-item":
+  version: 0.0.0-use.local
+  resolution: "@psu-ooe/random-item@workspace:packages/random-item"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- [x] Add configurable heading level
- [x] Add support for multiple / random images
- [x] Add "worst case scenario" fallback for if a user provides no image

See https://developers.outreach.psu.edu/54-beef-up-the-intro-form/?p=viewall-molecules-intro-form for new examples.