### PR TITLE
Tweak compact CTA padding

### DIFF
--- a/packages/cta/package.json
+++ b/packages/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/cta",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provides a CTA button.",
   "publishConfig": {
     "access": "public",

--- a/packages/cta/src/scss/_cta-block.scss
+++ b/packages/cta/src/scss/_cta-block.scss
@@ -62,7 +62,7 @@
 
   &--compact {
     font-size: 1.1rem;
-    padding: 1.4rem 0.5rem;
+    padding: 1.4rem 0.8rem;
 
     @include bp(m) {
       padding: 1.4rem 2.2rem;


### PR DESCRIPTION
Matt would like `0.8rem` padding on the `cta--compact` flavor under 950px.

This should not prove to be disruptive and is required to proceed with the new sticky banner.