### PR TITLE
Fix a confusing overflow quirk

### DIFF
--- a/packages/background-container/background-container.twig
+++ b/packages/background-container/background-container.twig
@@ -23,11 +23,13 @@
 {% endif %}
 <div class="{{ classes|join(' ') }}">
   {% if sprites %}
+    <div class="bg__sprites">
     {% for sprite in sprites %}
       <div class="bg__sprite bg__sprite--{{sprite}} bg__sprite--{{loop.index}}">
 		    {% include '@atoms/sprite/sprite.twig' with { name: sprite } only %}
 		  </div>
     {% endfor %}
+    </div>
   {% endif %}
   {{ content }}
 </div>

--- a/packages/background-container/package.json
+++ b/packages/background-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/background-container",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Provides a container that supports background sprites.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/background-container/src/scss/_shield-bottomright.scss
+++ b/packages/background-container/src/scss/_shield-bottomright.scss
@@ -1,7 +1,6 @@
 &.bg--shield-bottomright {
   .bg__sprite {
     position: absolute;
-    z-index:-1;
     width: rem(8.6);
     height: rem(16.2);
     max-height: 100%;
@@ -11,7 +10,6 @@
 
     .sprite {
       position: absolute;
-      z-index: -1;
       height: auto;
       width: rem(72.2);
       right: rem(-6.9);

--- a/packages/background-container/src/scss/_shield-left.scss
+++ b/packages/background-container/src/scss/_shield-left.scss
@@ -1,7 +1,6 @@
 &.bg--shield-left {
   .bg__sprite .sprite {
     position: absolute;
-    z-index: -1;
     height: auto;
     width: rem(70);
     left: rem(-62);

--- a/packages/background-container/src/scss/_shield-program-page-at-a-glance.scss
+++ b/packages/background-container/src/scss/_shield-program-page-at-a-glance.scss
@@ -1,7 +1,6 @@
 &.bg--shield-program-page-at-a-glance {
   .bg__sprite .sprite {
     position: absolute;
-    z-index: -1;
     width: rem(53.2);
     height: auto;
     right: rem(-32);

--- a/packages/background-container/src/scss/_shield-program-page-banner-top.scss
+++ b/packages/background-container/src/scss/_shield-program-page-banner-top.scss
@@ -1,7 +1,6 @@
 &.bg--shield-program-page-banner-top {
   .bg__sprite .sprite {
     position: absolute;
-    z-index: -1;
     width: rem(53.2);
     height: auto;
     left: rem(-22.3);

--- a/packages/background-container/src/scss/_shield-right.scss
+++ b/packages/background-container/src/scss/_shield-right.scss
@@ -1,7 +1,6 @@
 &.bg--shield-right {
   .bg__sprite .sprite {
     position: absolute;
-    z-index: -1;
     height: auto;
     width: rem(70);
     right: rem(-58);

--- a/packages/background-container/src/scss/_shield-topleft-bottomright.scss
+++ b/packages/background-container/src/scss/_shield-topleft-bottomright.scss
@@ -1,7 +1,6 @@
 &.bg--shield-topleft-bottomright {
   .bg__sprite .sprite {
     position: absolute;
-    z-index: -1;
     height: auto;
     display: none;
 

--- a/packages/background-container/src/scss/styles.scss
+++ b/packages/background-container/src/scss/styles.scss
@@ -53,6 +53,7 @@
     position: absolute;
     overflow: hidden;
     inset: 0 0 0 0;
+    z-index: -1;
   }
 
 	@import "shield-left";

--- a/packages/background-container/src/scss/styles.scss
+++ b/packages/background-container/src/scss/styles.scss
@@ -9,7 +9,6 @@
   padding-top: rem(3);
   padding-bottom: rem(3);
   position: relative;
-  overflow: hidden;
 
   //noinspection CssUnknownProperty
   @supports (container-type: inline-size ) {
@@ -48,6 +47,12 @@
     &--#{$color} {
       background-color: #{$scss_color};
     }
+  }
+
+  &__sprites {
+    position: absolute;
+    overflow: hidden;
+    inset: 0 0 0 0;
   }
 
 	@import "shield-left";

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.43",
+  "version": "1.0.44",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/background-container/background-container.twig
+++ b/packages/patternlab/source/patterns/molecules/background-container/background-container.twig
@@ -115,3 +115,19 @@
             <br />
     {% endfor %}
 {% endfor %}
+
+{% set overflowing_content %}
+  <div style="padding: 0 4rem">
+    <h2 style="color:black;margin-top:-10rem;margin-bottom:5rem;">I'm overflowing!!!</h2>
+    <h3>Overflowing content</h3>
+    <p>This content is overflowing!</p>
+  </div>
+{% endset %}
+
+<div style="max-width:119rem;padding:0 4rem;margin-top:6rem;">
+  {% include '@molecules/background-container/background-container.twig' with {
+    color: 'primary-blue',
+    background_image: 'shield:right',
+    content: overflowing_content
+  } only %}
+</div>


### PR DESCRIPTION
1. Remove `overflow: hidden` from outer-most container element.
2. Add a new div around all sprites that might exist.
3. Absolutely position new div with `inset: 0 0 0 0`