### PR TITLE
Add an option to the overlay component that can extend a blurred version of the image below the container on small viewports

### DIFF
--- a/packages/overlay/overlay.twig
+++ b/packages/overlay/overlay.twig
@@ -21,4 +21,5 @@
   <div class="overlay__column">
     <div class="overlay__content"> {{ content }} </div>
   </div>
+  <div class="overlay__divider">{{ image }}</div>
 </div>

--- a/packages/overlay/overlay.twig
+++ b/packages/overlay/overlay.twig
@@ -21,5 +21,7 @@
   <div class="overlay__column">
     <div class="overlay__content"> {{ content }} </div>
   </div>
-  <div class="overlay__divider">{{ image }}</div>
+  {% if show_divider %}
+    <div class="overlay__divider">{{ image }}</div>
+  {% endif %}
 </div>

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/overlay",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Provides an overlay implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/overlay",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides an overlay implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/overlay/src/scss/styles.scss
+++ b/packages/overlay/src/scss/styles.scss
@@ -53,7 +53,7 @@
   }
 
   .overlay__divider {
-
+    overflow: hidden;
     @include bp(s) {
       display: none;
     }
@@ -62,6 +62,8 @@
       height: 2rem;
       object-fit: cover;
       object-position: bottom;
+      filter: blur(rem(.5));
+      transform: scale(2);
     }
   }
 

--- a/packages/overlay/src/scss/styles.scss
+++ b/packages/overlay/src/scss/styles.scss
@@ -53,17 +53,17 @@
   }
 
   .overlay__divider {
+    height: 2rem;
     overflow: hidden;
+    position: relative;
+
     @include bp(s) {
       display: none;
     }
 
     img {
-      height: 2rem;
-      object-fit: cover;
-      object-position: bottom;
-      filter: blur(rem(.5));
-      transform: scale(2);
+      position: absolute;
+      bottom: 0;
     }
   }
 

--- a/packages/overlay/src/scss/styles.scss
+++ b/packages/overlay/src/scss/styles.scss
@@ -63,12 +63,12 @@
 
     img {
       position: absolute;
-      bottom: -10px;
+      bottom: rem(-1);
       max-width: unset;
-      width: calc(100% + 20px);
+      width: calc(100% + #{rem(2)});
       height: 5000%;
-      margin-left: -10px;
-      filter: blur(10px);
+      margin-left: rem(-1);
+      filter: blur(#{rem(1)});
     }
   }
 

--- a/packages/overlay/src/scss/styles.scss
+++ b/packages/overlay/src/scss/styles.scss
@@ -63,7 +63,11 @@
 
     img {
       position: absolute;
-      bottom: 0;
+      bottom: -5px;
+      max-width: unset;
+      width: 150%;
+      margin-left: -25%;
+      filter: blur(5px);
     }
   }
 

--- a/packages/overlay/src/scss/styles.scss
+++ b/packages/overlay/src/scss/styles.scss
@@ -52,6 +52,19 @@
     }
   }
 
+  .overlay__divider {
+
+    @include bp(s) {
+      display: none;
+    }
+
+    img {
+      height: 2rem;
+      object-fit: cover;
+      object-position: bottom;
+    }
+  }
+
   &--beaver-blue {
     .overlay__content {
       background: $beaver-blue;

--- a/packages/overlay/src/scss/styles.scss
+++ b/packages/overlay/src/scss/styles.scss
@@ -63,11 +63,12 @@
 
     img {
       position: absolute;
-      bottom: -5px;
+      bottom: -10px;
       max-width: unset;
-      width: 150%;
-      margin-left: -25%;
-      filter: blur(5px);
+      width: calc(100% + 20px);
+      height: 5000%;
+      margin-left: -10px;
+      filter: blur(10px);
     }
   }
 

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/overlay/~overlay-show-divider.twig
+++ b/packages/patternlab/source/patterns/molecules/overlay/~overlay-show-divider.twig
@@ -1,0 +1,27 @@
+{% set content %}
+  {% include '@organisms/quote/quote.twig' with {
+    headshot: "",
+    reverse: false,
+    quote: "Penn State has a long and strong history of educating learners at a distance. I look forward to leading the Online Education team to further the reputation of excellence that has been established.",
+    attribution: "Renata S. Engel, Ph.D.",
+    byline: "Vice Provost for Online Education",
+    after_quote: "This is after quote content."
+  } %}
+{% endset %}
+{% set image %}
+  <picture>
+    <source srcset="//test.worldcampus.psu.edu/sites/default/files/styles/feature_banner_16_7_xl/public/2018-12/1920x1018_Engel_feature.webp?itok=Zb1tP_sm 1x" media="(min-width:800px)" type="image/webp" width="1920" height="840">
+    <source srcset="//test.worldcampus.psu.edu/sites/default/files/styles/feature_banner_16_9_m/public/2018-12/1920x1018_Engel_feature.webp?itok=A1yNaUjl 1x" type="image/webp" width="950" height="534">
+    <source srcset="//test.worldcampus.psu.edu/sites/default/files/styles/feature_banner_16_7_xl/public/2018-12/1920x1018_Engel_feature.jpg?itok=Zb1tP_sm 1x" media="(min-width:800px)" type="image/jpeg" width="1920" height="840">
+    <source srcset="//test.worldcampus.psu.edu/sites/default/files/styles/feature_banner_16_9_m/public/2018-12/1920x1018_Engel_feature.jpg?itok=A1yNaUjl 1x" type="image/jpeg" width="950" height="534">
+    <img src="//test.worldcampus.psu.edu/sites/default/files/styles/feature_banner_16_7_xl/public/2018-12/1920x1018_Engel_feature.jpg?itok=Zb1tP_sm" width="1920" height="840" alt="Renata Engel" loading="lazy">
+  </picture>
+{% endset %}
+{% include '@molecules/overlay/overlay.twig' with {
+  image: image,
+  content: content,
+  overlay_bg_color: "beaver-blue",
+  column_width: "narrow",
+  overlay_width: "normal",
+  show_divider: true
+} %}


### PR DESCRIPTION
This is required for program pages.

On small viewports, repeat the image rendering (which won't cause additional requests -- it's the same image as above), blur it, apply some transformations, and call it a day.