### PR TITLE
Missing CTA dependency in expandable section

### DIFF
--- a/packages/expandable-section/package.json
+++ b/packages/expandable-section/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/expandable-section",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Provides an expandable section implementation.",
   "publishConfig": {
     "access": "public",
@@ -9,6 +9,7 @@
   "dependencies": {
     "@psu-ooe/auto-expansion": "^1.0",
     "@psu-ooe/base": "^1.0",
+    "@psu-ooe/cta": "^1.0",
     "@psu-ooe/polyfill-focus-visible": "^1.0",
     "@psu-ooe/slide-toggle": "^1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,6 +1620,7 @@ __metadata:
   dependencies:
     "@psu-ooe/auto-expansion": ^1.0
     "@psu-ooe/base": ^1.0
+    "@psu-ooe/cta": ^1.0
     "@psu-ooe/polyfill-focus-visible": ^1.0
     "@psu-ooe/slide-toggle": ^1.0
   languageName: unknown


### PR DESCRIPTION
This is causing an order mismatch in wcstudent due to the package.json controlling dependencies.