### PR TITLE
Add wrapping element around accordion expand/collapse sprite

### DIFF
--- a/packages/accordion/accordion.twig
+++ b/packages/accordion/accordion.twig
@@ -19,7 +19,9 @@
   {% endif %}
   <button class="accordion__button" aria-expanded="{{ expanded ? 'true' : 'false' }}" aria-controls="{{ id }}">
     <span class="accordion__label">{{ label }}</span>
-    {% include '@atoms/sprite/sprite.twig' with { name: 'fas-plus'} only %}
+    <span class="accordion__sprite">
+      {% include '@atoms/sprite/sprite.twig' with { name: 'fas-plus'} only %}
+    </span>
   </button>
   {% if heading_level %}
     </{{ heading_level }}>

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/accordion",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Provides an accessible accordion implementation.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/accordion/src/js/scripts.js
+++ b/packages/accordion/src/js/scripts.js
@@ -12,7 +12,7 @@
 
         // Update the transition duration for the open/close animation.
         const transition = Math.max(content.scrollHeight / 2, 200) + 'ms';
-        button.querySelector('.sprite').style['transition-duration'] = transition;
+        button.querySelector('.accordion__sprite .sprite').style['transition-duration'] = transition;
         content.style['transition-duration'] = transition;
 
         const state = button.getAttribute('aria-expanded');

--- a/packages/accordion/src/scss/styles.scss
+++ b/packages/accordion/src/scss/styles.scss
@@ -46,7 +46,7 @@
         text-decoration-color: $primary-blue;
       }
 
-      .sprite {
+      .accordion__sprite .sprite {
         transform: scale(1.25);
       }
     }
@@ -64,7 +64,7 @@
         text-decoration-color: $primary-blue;
       }
 
-      .sprite {
+      .accordion__sprite .sprite {
         transform: scale(1.25);
       }
     }
@@ -80,7 +80,7 @@
     transition: color .2s linear, text-decoration-color .2s linear;
   }
 
-  .sprite {
+  .accordion__sprite .sprite {
     color: $primary-blue;
     height: rem(1.6);
     margin: auto rem(1.5);
@@ -99,12 +99,12 @@
 
    > .accordion__button,
    > .accordion__heading {
-      .sprite {
+      .accordion__sprite .sprite {
         transform: rotate(45deg);
       }
 
       &:hover {
-        .sprite {
+        .accordion__sprite .sprite {
           transform: rotate(45deg) scale(1.25);
         }
       }
@@ -112,7 +112,7 @@
       &:focus-visible {
         margin-bottom: rem(.3);
 
-        .sprite {
+        .accordion__sprite .sprite {
           transform: rotate(45deg) scale(1.25);
         }
       }
@@ -138,13 +138,13 @@
       text-decoration-color: $primary-blue;
     }
 
-    .sprite {
+    .accordion__sprite .sprite {
       color: $primary-blue;
       transform: scale(1.25);
     }
   }
 
-  &--expanded .accordion__button.focus-visible .sprite {
+  &--expanded .accordion__button.focus-visible .accordion__sprite .sprite {
     transform: rotate(45deg) scale(1.25);
   }
 }

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/accordion/accordion~nested-cta-sprite.twig
+++ b/packages/patternlab/source/patterns/molecules/accordion/accordion~nested-cta-sprite.twig
@@ -1,0 +1,12 @@
+{% set nested_cta_sprite %}
+  {% include '@atoms/cta/cta-block.twig' with {
+    label: 'How to Apply',
+    url: '#',
+    icon_after: 'fas-chevron-right'
+  } only %}
+{% endset %}
+{% include '@molecules/accordion/accordion.twig' with {
+    "id": "accordion-default",
+    "label": "Accordion item (default)",
+    "expandable_content": nested_cta_sprite
+} only %}

--- a/packages/patternlab/source/patterns/molecules/accordion/accordion~nested-sprite.twig
+++ b/packages/patternlab/source/patterns/molecules/accordion/accordion~nested-sprite.twig
@@ -1,0 +1,8 @@
+{% set nested_sprite %}
+  {% include '@atoms/sprite/sprite.twig' with { name: 'wc-mark' } only %}
+{% endset %}
+{% include '@molecules/accordion/accordion.twig' with {
+    "id": "accordion-default",
+    "label": "Accordion item (default)",
+    "expandable_content": "This is the accordion content." ~ nested_sprite
+} only %}


### PR DESCRIPTION
Kyle was running into issues where if accordion content contains a sprite, it rotates / scales strangely.

This is because the selectors used by the accordion to target its own sprite is too generic.

To resolve, we simply wrap an element around it namespaced with `accordion__` to ensure no collisions occur.

See the new example at https://developers.outreach.psu.edu/91-accordion-component-wrapper/?p=viewall-molecules-accordion