### PR TITLE
Add optional toc variable to expandable section

### DIFF
--- a/packages/expandable-section/expandable-section.twig
+++ b/packages/expandable-section/expandable-section.twig
@@ -1,4 +1,4 @@
-<div class="expandable-section" data-interactive-component{% if id %} id="{{ id }}"{% endif %}>
+<div class="expandable-section" data-interactive-component{% if id %} id="{{ id }}"{% endif %}{% if toc_label %} data-toc-label="{{ toc_label }}"{% endif %}>
   {% if intro %}
     <div class="expandable-section__intro">
       {{ intro }}

--- a/packages/expandable-section/package.json
+++ b/packages/expandable-section/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/expandable-section",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Provides an expandable section implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/organisms/expandable-section/_expandable-section.md
+++ b/packages/patternlab/source/patterns/organisms/expandable-section/_expandable-section.md
@@ -3,9 +3,11 @@ title: Expandable Section
 ---
 
 ### Variables
-| Variable       | Type   | Required | Description                                                        |
-|----------------|--------|----------|--------------------------------------------------------------------|
-| intro          | string | false    | The always-visible content to render before the expanable section. |
-| expand_label   | string | true     | The label to use for the "expand" button.                          |
-| collapse_label | string | true     | The label to use for the "collapse" button.                        |
-| content        | string | true     | The content to progressively display behind the "expand" button.   |
+| Variable       | Type   | Required | Description                                                         |
+|----------------|--------|----------|---------------------------------------------------------------------|
+| intro          | string | false    | The always-visible content to render before the expandable section. |
+| expand_label   | string | true     | The label to use for the "expand" button.                           |
+| collapse_label | string | true     | The label to use for the "collapse" button.                         |
+| content        | string | true     | The content to progressively display behind the "expand" button.    |
+| id             | string | false    | An optional id attribute.                                           |
+| toc_label      | string | false    | An optional table of contents data attribute.                       |

--- a/packages/patternlab/source/patterns/organisms/expandable-section/expandable-section.twig
+++ b/packages/patternlab/source/patterns/organisms/expandable-section/expandable-section.twig
@@ -1,4 +1,6 @@
 {% include '@organisms/expandable-section/expandable-section.twig' with {
+  id: 'expandable-section',
+  toc_label: 'Minors',
   intro: "<div class=\"wysiwyg\"><h2 class=\"heading--neutral heading--flush\">Minors</h2><p>Penn State World Campus students can optionally supplement their degree with a minor.</p></div>",
   expand_label: "View Minors",
   content: "<div class=\"grid grid--three-col\"><div class=\"grid__item\" style=\"min-height:10rem;margin:auto;line-height:10rem\"><a href=\"#\">Item 1</a></div><div class=\"grid__item\" style=\"min-height:10rem;margin:auto;line-height:10rem\"><a href=\"#\">Item 2</a></div><div class=\"grid__item\" style=\"min-height:10rem;margin:auto;line-height:10rem\"><a href=\"#\">Item 3</a></div><div class=\"grid__item\" style=\"min-height:10rem;margin:auto;line-height:10rem\"><a href=\"#\">Item 4</a></div><div class=\"grid__item\" style=\"min-height:10rem;margin:auto;line-height:10rem\"><a href=\"#\">Item 5</a></div></div>",

--- a/packages/patternlab/source/patterns/organisms/expandable-section/expandable-section.twig
+++ b/packages/patternlab/source/patterns/organisms/expandable-section/expandable-section.twig
@@ -1,5 +1,5 @@
 {% include '@organisms/expandable-section/expandable-section.twig' with {
-  id: 'expandable-section',
+  id: 'minors',
   toc_label: 'Minors',
   intro: "<div class=\"wysiwyg\"><h2 class=\"heading--neutral heading--flush\">Minors</h2><p>Penn State World Campus students can optionally supplement their degree with a minor.</p></div>",
   expand_label: "View Minors",


### PR DESCRIPTION
We need to be able to add the `data-toc-label` attribute to expandable sections.

See https://developers.outreach.psu.edu/add-toc-to-expandable-section/?p=viewall-organisms-expandable-section for an example