### PR TITLE
Adding new examples of missing color variables from the base variables.

### DIFF
--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/visual-styles/colors/color-system.twig
+++ b/packages/patternlab/source/patterns/visual-styles/colors/color-system.twig
@@ -2,10 +2,11 @@
     set colors = {
     'primary blue': { hex_code:  '#0064bf', scss_variable: '$primary-blue' },
     'beaver blue': { hex_code:  '#1e407c', scss_variable: '$beaver-blue' },
+    'sky blue': { hex_code: '#009cde', scss_variable: '$sky-blue' },
     'nittany navy': { hex_code:  '#001e44', scss_variable: '$nittany-navy' },
     'nittany navy (faded)': { hex_code: '#001e4480', scss_variable: '$nittany-navy-faded'},
     'true blue': { hex_code:  '#0056ae', scss_variable: '$true-blue' },
-    'pugh-blue': { hex_code:  '#96bee6', scss_variable: '$pugh-blue' },
+    'pugh blue': { hex_code:  '#96bee6', scss_variable: '$pugh-blue' },
     'light mauve': { hex_code:  '#ebecf4', scss_variable: '$light-mauve' },
     'light grey': { hex_code:  '#f2f3f9', scss_variable: '$light-grey' },
     'medium grey': { hex_code:  '#d8dbea', scss_variable: '$medium-grey' },
@@ -13,9 +14,11 @@
     'slate': { hex_code:  '#314d64', scss_variable: '$slate' },
     'slate light': { hex_code:  '#ccdae6', scss_variable: '$slate-light' },
     'keystone': { hex_code:  '#ffd100', scss_variable: '$keystone' },
+    'keystone light': { hex_code: '#f9df70', scss_variable: '$keystone-light' },
+    'limestone': { hex_code: '#a2aaad', scss_variable: '$limestone' },
     'invent orange': { hex_code:  '#e98300', scss_variable: '$invent-orange' },
     'invent orange light': { hex_code:  '#fca917', scss_variable: '$invent-orange-light' },
-    'penns-forest': { hex_code: '#4A7729', scss_variable: '$penns-forest' },
+    'penns forest': { hex_code: '#4A7729', scss_variable: '$penns-forest' },
 }
 %}
 


### PR DESCRIPTION
Adding the following:

sky blue
keystone light
limestone

Updating display key of the following to remove "-" for consistency:
penns forest
pugh blue