### PR TITLE
Fix intro form for safari 16.4...

### DIFF
--- a/packages/intro-form/package.json
+++ b/packages/intro-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/intro-form",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Provides a specialized container for presenting a form with accompanying intro content.",
   "publishConfig": {
     "access": "public",

--- a/packages/intro-form/src/scss/styles.scss
+++ b/packages/intro-form/src/scss/styles.scss
@@ -100,10 +100,11 @@
     line-height: 1.15;
     font-weight: 400;
     background: $primary-blue;
-    padding: rem(1) rem(1.5);
-    margin: 0;
+    padding: rem(1) 0;
+    margin: 0 rem(1.5);
     box-decoration-break: clone;
     -webkit-box-decoration-break: clone;
+    box-shadow: rem(-1.5) 0 0 $primary-blue, rem(1.5) 0 0 $primary-blue;
     color: $white;
   }
 


### PR DESCRIPTION
# Description:
Fix the missing padding right for the intro form component (just like we did for highlighted text..).

## Metadata
Delete sections that are not relevant.

### Workfront Task Link
TBD
### Review environment Link
https://developers.outreach.psu.edu/intro-form-safari-fix/?p=viewall-molecules-intro-form