### PR TITLE
Add two column grid variant

### DIFF
--- a/packages/grid/grid.twig
+++ b/packages/grid/grid.twig
@@ -1,4 +1,4 @@
-{% set column_map = {3: 'three-col', 4: 'four-col'} %}
+{% set column_map = {2: 'two-col', 3: 'three-col', 4: 'four-col'} %}
 <div class="grid grid--{{ column_map[columns] ?: column_map[3] }}">
   {% for item in items %}
     <div class="grid__item">

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/grid",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Provides a grid component.",
   "publishConfig": {
     "access": "public",

--- a/packages/grid/src/scss/styles.scss
+++ b/packages/grid/src/scss/styles.scss
@@ -6,6 +6,10 @@
   margin: 0;
   padding: 0;
 
+  &--two-col {
+    grid-template-columns: repeat(auto-fill, minmax(max(48%, min(24rem, 100%)), 1fr));
+  }
+
   &--three-col {
     grid-template-columns: repeat(auto-fill, minmax(unquote('max(30%, #{unquote('min(#{rem(24)}, 100%)')})'), 1fr));
   }

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/grid/grid~2-column.twig
+++ b/packages/patternlab/source/patterns/molecules/grid/grid~2-column.twig
@@ -1,0 +1,10 @@
+{% include '@molecules/grid/grid.twig' with {
+  items: [
+    'Item 1',
+    'Item 2',
+    'Item 3',
+    'Item 4',
+    'Item 5',
+  ],
+  columns: 2,
+} only %}


### PR DESCRIPTION
# Description:
In order to phase out the old tile stuff from the prospect site, we need a 2-column grid for the RFI thank-you page.

## Metadata

### Review environment Link
https://developers.outreach.psu.edu/two-column-grid/?p=viewall-molecules-grid