### PR TITLE
Container queries

### DIFF
--- a/packages/base/src/scss/imports/_layout.scss
+++ b/packages/base/src/scss/imports/_layout.scss
@@ -87,47 +87,47 @@ $bp_xl: 1280px;
 ///   }
 @mixin container($point) {
   @if $point == xxs {
-    @container (min-width: #{$bp_xxs}) {
+    @container (min-width: #{$bp_xxs - 40px}) {
       @content;
     }
   } @else if $point == xs {
-    @container (min-width: #{$bp_xs}) {
+    @container (min-width: #{$bp_xs - 40px}) {
       @content;
     }
   } @else if $point == xs_max {
-    @container (max-width: #{$bp_xs_max}) {
+    @container (max-width: #{$bp_xs_max - 40px}) {
       @content;
     }
   } @else if $point == s {
-    @container (min-width: #{$bp_s}) {
+    @container (min-width: #{$bp_s - 40px}) {
       @content;
     }
   } @else if $point == s_max {
-    @container (max-width: #{$bp_s_max}) {
+    @container (max-width: #{$bp_s_max - 40px}) {
       @content;
     }
   } @else if $point == smaller {
-    @container (min-width: #{$bp-smaller}) {
+    @container (min-width: #{$bp-smaller - 40px}) {
       @content;
     }
   } @else if $point == m {
-    @container (min-width: #{$bp_m}) {
+    @container (min-width: #{$bp_m - 40px}) {
       @content;
     }
   } @else if $point == m_max {
-    @container (max-width: #{$bp_m_max}) {
+    @container (max-width: #{$bp_m_max - 40px}) {
       @content;
     }
   } @else if $point == l {
-    @container (min-width: #{$bp_l}) {
+    @container (min-width: #{$bp_l - 40px}) {
       @content;
     }
   } @else if $point == 1030 {
-    @container (min-width: #{$bp_1030}) {
+    @container (min-width: #{$bp_1030 - 40px}) {
       @content;
     }
   } @else if $point == xl {
-    @container (min-width: #{$bp_xl}) {
+    @container (min-width: #{$bp_xl - 40px}) {
       @content;
     }
   }

--- a/packages/base/src/scss/imports/_layout.scss
+++ b/packages/base/src/scss/imports/_layout.scss
@@ -71,6 +71,20 @@ $bp_xl: 1280px;
   }
 }
 
+/// Container query output.
+///
+/// @param {String} $point - The point at which the query takes effect.
+///
+/// @example scss - Apply a style above 550px to `.some-element`
+///   .some-element-container {
+///     container-type: inline-size;
+///   }
+///
+///   .some-element {
+///     @include container(xs) {
+///       background-color: green;
+///     }
+///   }
 @mixin container($point) {
   @if $point == xxs {
     @container (min-width: #{$bp_xxs}) {
@@ -119,6 +133,23 @@ $bp_xl: 1280px;
   }
 }
 
+
+/// Container query output with media query fallback.
+///
+/// @param {String} $point - The point at which the query takes effect.
+///
+/// @example scss - Apply a style above 550px to `.some-element`
+///   .some-element-container {
+///     @supports (container-type: inline-size) {
+///       container-type: inline-size;
+///     }
+///   }
+///
+///   .some-element {
+///     @include container-with-fallback(xs) {
+///       background-color: green;
+///     }
+///   }
 @mixin container-with-fallback($point) {
   @supports (container-type: inline-size) {
     @include container($point) {

--- a/packages/base/src/scss/imports/_layout.scss
+++ b/packages/base/src/scss/imports/_layout.scss
@@ -95,39 +95,39 @@ $bp_xl: 1280px;
       @content;
     }
   } @else if $point == xs_max {
-    @container (max-width: #{$bp_xs_max - 40px}) {
+    @container (max-width: #{$bp_xs_max - 80px}) {
       @content;
     }
   } @else if $point == s {
-    @container (min-width: #{$bp_s - 40px}) {
+    @container (min-width: #{$bp_s - 80px}) {
       @content;
     }
   } @else if $point == s_max {
-    @container (max-width: #{$bp_s_max - 40px}) {
+    @container (max-width: #{$bp_s_max - 80px}) {
       @content;
     }
   } @else if $point == smaller {
-    @container (min-width: #{$bp-smaller - 40px}) {
+    @container (min-width: #{$bp-smaller - 80px}) {
       @content;
     }
   } @else if $point == m {
-    @container (min-width: #{$bp_m - 40px}) {
+    @container (min-width: #{$bp_m - 80px}) {
       @content;
     }
   } @else if $point == m_max {
-    @container (max-width: #{$bp_m_max - 40px}) {
+    @container (max-width: #{$bp_m_max - 80px}) {
       @content;
     }
   } @else if $point == l {
-    @container (min-width: #{$bp_l - 40px}) {
+    @container (min-width: #{$bp_l - 80px}) {
       @content;
     }
   } @else if $point == 1030 {
-    @container (min-width: #{$bp_1030 - 40px}) {
+    @container (min-width: #{$bp_1030 - 80px}) {
       @content;
     }
   } @else if $point == xl {
-    @container (min-width: #{$bp_xl - 40px}) {
+    @container (min-width: #{$bp_xl - 80px}) {
       @content;
     }
   }

--- a/packages/base/src/scss/imports/_layout.scss
+++ b/packages/base/src/scss/imports/_layout.scss
@@ -71,6 +71,68 @@ $bp_xl: 1280px;
   }
 }
 
+@mixin container($point) {
+  @if $point == xxs {
+    @container (min-width: #{$bp_xxs}) {
+      @content;
+    }
+  } @else if $point == xs {
+    @container (min-width: #{$bp_xs}) {
+      @content;
+    }
+  } @else if $point == xs_max {
+    @container (max-width: #{$bp_xs_max}) {
+      @content;
+    }
+  } @else if $point == s {
+    @container (min-width: #{$bp_s}) {
+      @content;
+    }
+  } @else if $point == s_max {
+    @container (max-width: #{$bp_s_max}) {
+      @content;
+    }
+  } @else if $point == smaller {
+    @container (min-width: #{$bp-smaller}) {
+      @content;
+    }
+  } @else if $point == m {
+    @container (min-width: #{$bp_m}) {
+      @content;
+    }
+  } @else if $point == m_max {
+    @container (max-width: #{$bp_m_max}) {
+      @content;
+    }
+  } @else if $point == l {
+    @container (min-width: #{$bp_l}) {
+      @content;
+    }
+  } @else if $point == 1030 {
+    @container (min-width: #{$bp_1030}) {
+      @content;
+    }
+  } @else if $point == xl {
+    @container (min-width: #{$bp_xl}) {
+      @content;
+    }
+  }
+}
+
+@mixin container-with-fallback($point) {
+  @supports (container-type: inline-size) {
+    @include container($point) {
+      @content;
+    }
+  }
+
+  @supports (not (container-type: inline-size)) {
+    @include bp($point) {
+      @content;
+    }
+  }
+}
+
 // @TODO: Remove when not referenced by legacy layout styles.
 @mixin full-width-container {
   box-sizing: border-box;

--- a/packages/container-query-test/container-query-test.twig
+++ b/packages/container-query-test/container-query-test.twig
@@ -1,0 +1,7 @@
+<div id="container-query-test" style="margin:0 auto 5rem;max-width:80vw;">
+  <p>This container is red below 550px and green above.  This should only work on browsers that support container queries.</p>
+</div>
+
+<div id="container-query-with-fallback-test"  style="margin:auto;max-width:80vw;">
+  <p>If the browser supports container queries, this container is red below 550px.  If the browser does not support container queries, this container will be red when the <em>viewport</em> is below 550px.</em>.</p>
+</div>

--- a/packages/container-query-test/src/scss/styles.scss
+++ b/packages/container-query-test/src/scss/styles.scss
@@ -1,0 +1,28 @@
+@import "../../../base/src/scss/imports/layout";
+
+#container-query-test {
+  container-type: inline-size;
+  margin-bottom: 5rem;
+  p {
+    background-color: red;
+    padding: 3rem;
+
+    @include container(xs) {
+      background-color: green;
+    }
+  }
+}
+
+
+#container-query-with-fallback-test {
+  container-type: inline-size;
+
+  p {
+    background-color: red;
+    padding: 3rem;
+
+    @include container-with-fallback(xs) {
+      background-color: green;
+    }
+  }
+}

--- a/packages/patternlab/source/patterns/utility/container-queries/container-queries.twig
+++ b/packages/patternlab/source/patterns/utility/container-queries/container-queries.twig
@@ -1,0 +1,1 @@
+{% include '@atoms/container-query-test/container-query-test.twig' %}


### PR DESCRIPTION
# Description:
We need a way to generically apply container queries at controlled widths.

Given the following HTML:
```
<div class="some-container">
  <p class="some-paragraph">This is a paragraph.</p>
</div>
```

and the following SCSS:
```
.some-container {
  container-type: inline-size;
}

// Turn the paragraph green when its container exceeds 550px in width.
.some-paragraph {
  @include container(xs) {
    color: green;
  }
}
```

the paragraph should turn green when `some-container` reaches 550px in width.