### PR TITLE
Updating styles in alert componet to give the content a flex: 1 to al…

### DIFF
--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/alert",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides an alert.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/alert/src/scss/styles.scss
+++ b/packages/alert/src/scss/styles.scss
@@ -23,6 +23,9 @@
         height: rem(5.5);
       }
     }
+    .alert__content {
+      flex: 1;
+    }
   }
 
   &--error {


### PR DESCRIPTION
…low proper styling when an internal piece of content has a container-type.

# Description:
Due to the wysiwyg container that is added via Drupal's ckeditor, it has a container-type: inline-container, which is causing the alert__content div to not have a width. Specifying flex: 1 to the alert__content allows the text to freely go 100%.
See image.

![image](https://github.com/PSU-OOE/components/assets/105241099/1ab0493c-a1b5-4733-bcd1-5b475408e98b)


### Review environment Link
https://developers.outreach.psu.edu/alert-content-style/index.html