### PR TITLE
Move the Upcoming Events component heading

### DIFF
--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.76",
+  "version": "1.0.77",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~1.twig
+++ b/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~1.twig
@@ -3,7 +3,6 @@
     level: 2,
     content: "Upcoming Event",
     color: "neutral",
-    flush: true
   },
   events: [
     {

--- a/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~2.twig
+++ b/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~2.twig
@@ -3,7 +3,6 @@
     level: 2,
     content: "Upcoming Events",
     color: "neutral",
-    flush: true
   },
   events: [
     {

--- a/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~3.twig
+++ b/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~3.twig
@@ -3,7 +3,6 @@
     level: 2,
     content: "Upcoming Events",
     color: "neutral",
-    flush: true
   },
   events: [
     {

--- a/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~4.twig
+++ b/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~4.twig
@@ -3,7 +3,6 @@
     level: 2,
     content: "Upcoming Events",
     color: "neutral",
-    flush: true
   },
   events: [
     {

--- a/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~overflow-compact.twig
+++ b/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~overflow-compact.twig
@@ -4,7 +4,6 @@
     size: "medium",
     content: "Upcoming Events",
     color: "neutral",
-    flush: true
   },
   compact: true,
   events: [

--- a/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~overflow.twig
+++ b/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~overflow.twig
@@ -3,7 +3,6 @@
     level: 2,
     content: "Upcoming Events",
     color: "neutral",
-    flush: true
   },
   events: [
     {

--- a/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~visually-hidden-heading.twig
+++ b/packages/patternlab/source/patterns/organisms/upcoming-events/upcoming-events~visually-hidden-heading.twig
@@ -4,7 +4,6 @@
     size: "medium",
     content: "Upcoming Events",
     color: "neutral",
-    flush: true,
     classes: ["visually-hidden"]
   },
   events: [

--- a/packages/upcoming-events/package.json
+++ b/packages/upcoming-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/upcoming-events",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides an upcoming events block implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/upcoming-events/src/scss/styles.scss
+++ b/packages/upcoming-events/src/scss/styles.scss
@@ -3,14 +3,6 @@
 
 .upcoming-events {
 
-  &__heading {
-    margin-bottom: 0;
-
-    @include bp(s) {
-      width: rem(19);
-    }
-  }
-
   &__featured {
     display: flex;
     flex-direction: column;

--- a/packages/upcoming-events/upcoming-events.twig
+++ b/packages/upcoming-events/upcoming-events.twig
@@ -5,12 +5,12 @@
     compact: boolean - true to display in compact mode
 #}
 <div class="upcoming-events{% if compact %} upcoming-events--compact{% endif %}">
+  {% if heading %}
+    {% set heading_classes = heading.classes|default([])|merge(['upcoming-events__heading']) %}
+    {% set heading = heading|merge({classes: heading_classes}) %}
+    {% include '@atoms/heading/heading.twig' with heading only %}
+  {% endif %}
   <div class="upcoming-events__featured">
-    {% if heading %}
-      {% set heading_classes = heading.classes|default([])|merge(['upcoming-events__heading']) %}
-      {% set heading = heading|merge({classes: heading_classes}) %}
-      {% include '@atoms/heading/heading.twig' with heading only %}
-    {% endif %}
     {% for event in events|slice(0, 3) %}
       <div class="upcoming-events__event">
         {% include '@organisms/event-link/event-link.twig' with event|merge({


### PR DESCRIPTION
# Description:
Move the heading for the `Upcoming Events` component out of the flex wrapper to sit above the featured events.

## Metadata

### Workfront Task Link
  https://pennstateoutreach.my.workfront.com/task/646e16fb0006685e9b9131ba00b817b9/overview

### Review environment Link
  https://developers.outreach.psu.edu/move-events-heading/?p=viewall-organisms-upcoming-events