### PR TITLE
Add new CTA variations for milestone 4; fix rems

### DIFF
--- a/packages/cta/package.json
+++ b/packages/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/cta",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Provides a CTA button.",
   "publishConfig": {
     "access": "public",

--- a/packages/cta/src/scss/_cta-block.scss
+++ b/packages/cta/src/scss/_cta-block.scss
@@ -9,23 +9,23 @@
 .cta-block {
   border: none;
   display:inline-block;
-  padding: 1.5rem 3rem;
+  padding: rem(1.5) rem(3);
   font-family: $open-sans;
-  font-size:1.5rem;
+  font-size: rem(1.5);
   line-height:1em;
   font-weight:600;
   text-decoration:none;
-  border-radius: 0.2rem;
+  border-radius: rem(0.2);
   transition: background-color .2s ease-in-out, color .2s ease-in-out;
   text-align:center;
   color: $white;
   background: $primary-blue;
   margin-bottom: 0;
-  outline-offset: -.5rem;
+  outline-offset: rem(-.5);
   position: relative;
 
   @include bp(m) {
-    padding: 1.7rem 3.125rem;
+    padding: rem(1.7) rem(3.125);
   }
 
   &:focus {
@@ -40,8 +40,8 @@
   }
 
   &:focus-visible {
-    outline: .2rem solid $sky-blue;
-    outline-offset: -.5rem;
+    outline: rem(.2) solid $sky-blue;
+    outline-offset: rem(-.5);
     background-color: $nittany-navy;
     border-bottom: none;
     color: $white;
@@ -49,8 +49,8 @@
 
   // @TODO: Remove safari polyfill.
   &.focus-visible {
-    outline: .2rem solid $sky-blue;
-    outline-offset: -.5rem;
+    outline: rem(.2) solid $sky-blue;
+    outline-offset: rem(-.5);
     background-color: $nittany-navy;
     border-bottom: none;
     color: $white;
@@ -61,24 +61,24 @@
   }
 
   &--compact {
-    font-size: 1.1rem;
-    padding: 1.4rem 0.8rem;
+    font-size: rem(1.1);
+    padding: rem(1.4) rem(0.8);
 
     @include bp(m) {
-      padding: 1.4rem 2.2rem;
-      font-size: 1.5rem;
+      padding: rem(1.4) rem(2.2);
+      font-size: rem(1.5);
     }
   }
 
   &--campaign-legacy {
-    padding: 1.3rem 1.571rem;
-    font-size: 1.4rem;
+    padding: rem(1.3) rem(1.571);
+    font-size: rem(1.4);
 
     .cta-block__icon {
-      margin-left: -.4rem;
+      margin-left: rem(-.4);
       &::before {
         content: "\00a0\f106";
-        font-size: 1.2rem;
+        font-size: rem(1.2);
       }
     }
   }
@@ -91,8 +91,8 @@
   }
 
   &--shadow {
-    box-shadow: .1rem .1rem rgba(0,0,0,0.25);
-    filter: drop-shadow(-.1rem -.1rem 0 rgba(255,255,255,0.67));
+    box-shadow: rem(.1) rem(.1) rgba(0,0,0,0.25);
+    filter: drop-shadow(rem(-.1) rem(-.1) 0 rgba(255,255,255,0.67));
   }
 
   &--bold {
@@ -102,14 +102,14 @@
   &__icon {
     display: inline-flex;
     transition: color .2s ease-in-out;
-    font-size: 1.3rem;
+    font-size: rem(1.3);
     color: $light-mauve;
     vertical-align: middle;
     &--before {
-      margin-right: 0.8rem;
+      margin-right: rem(0.8);
     }
     &--after {
-      margin-left: 0.8rem;
+      margin-left: rem(0.8);
     }
 
     .sprite {
@@ -163,21 +163,39 @@
 @include cta-color('reversed', $white, $nittany-navy,$nittany-navy, $white, $sky-blue, $primary-blue, $light-mauve);
 @include cta-color('color-keystone', $keystone, $black,$invent-orange-light, $black, $black, $black, $black);
 @include cta-color('expand', var(--cta-block-expand-background-color), $beaver-blue, $pugh-blue, $nittany-navy, $nittany-navy, $beaver-blue, $nittany-navy);
+@include cta-color('hollow-solid', transparent, $beaver-blue, $pugh-blue, $nittany-navy, $nittany-navy, $beaver-blue, $nittany-navy);
+@include cta-color('hollow-dotted', transparent, $beaver-blue, $pugh-blue, $nittany-navy, $nittany-navy, $beaver-blue, $nittany-navy);
 
 .cta-block--expand {
   transition: color .3s linear, background-color .3s linear, box-shadow .3s linear;
-  box-shadow: .1rem .1rem 0 0 rgba($beaver-blue, .5);
+  box-shadow: rem(.1) rem(.1) 0 0 rgba($beaver-blue, .5);
 
   &:focus-visible, &:hover {
-    box-shadow: .1rem .1rem 0 0 rgba($nittany-navy, .5);
+    box-shadow: rem(.1) rem(.1) 0 0 rgba($nittany-navy, .5);
   }
 
   // @TODO: Remove safari polyfill.
   &.focus-visible {
-    box-shadow: .1rem .1rem 0 0 rgba($nittany-navy, .5);
+    box-shadow: rem(.1) rem(.1) 0 0 rgba($nittany-navy, .5);
   }
 
   &:is(.bg--light-grey *) {
     --cta-block-expand-background-color: var(--cta-block-expand-background-color-light);
+  }
+}
+
+.cta-block--hollow {
+
+  &-dotted {
+    &, &:hover, &:focus {
+      border: rem(.1) $primary-blue dotted;
+
+    }
+  }
+
+  &-solid {
+    &, &:hover, &:focus {
+      border: rem(.1) $primary-blue solid;
+    }
   }
 }

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.81",
+  "version": "1.0.82",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/atoms/cta/cta~color-hollow-dotted.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~color-hollow-dotted.twig
@@ -1,0 +1,17 @@
+{% set cta %}
+  {% include '@atoms/cta/cta-block.twig' with {
+    label: 'View Minors',
+    url: '#',
+    color: 'hollow-dotted',
+  } only %}
+{% endset %}
+
+{% include '@molecules/background-container/background-container.twig' with {
+  color: 'white',
+  content: cta,
+} only %}
+
+{% include '@molecules/background-container/background-container.twig' with {
+  color: 'light-grey',
+  content: cta,
+} only %}

--- a/packages/patternlab/source/patterns/atoms/cta/cta~color-hollow-solid.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~color-hollow-solid.twig
@@ -1,0 +1,17 @@
+{% set cta %}
+  {% include '@atoms/cta/cta-block.twig' with {
+    label: 'View Minors',
+    url: '#',
+    color: 'hollow-solid',
+  } only %}
+{% endset %}
+
+{% include '@molecules/background-container/background-container.twig' with {
+  color: 'white',
+  content: cta,
+} only %}
+
+{% include '@molecules/background-container/background-container.twig' with {
+  color: 'light-grey',
+  content: cta,
+} only %}


### PR DESCRIPTION
# Description:
We need to add two new CTA variants for program pages milestone 4: "hollow solid" and "hollow dotted".

I took this opportunity to also REMify the CTA component, as that was causing display issues on the student site wysiwyg in the admin theme.

## Metadata
Delete sections that are not relevant.

### Workfront Task Link
  https://pennstateoutreach.my.workfront.com/task/64a5e4980033e220ba0731bccc8be8d8/overview
### Adobe XD Link
  https://xd.adobe.com/view/98d5236c-b8ef-45c6-af92-3fce077161d2-cd86/

### Review environment Link
  https://developers.outreach.psu.edu/new-cta-stuff/?p=viewall-atoms-cta