### PR TITLE
Add max width to dropbutton sprite to prevent overflowing

### DIFF
--- a/packages/drop-button/package.json
+++ b/packages/drop-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/drop-button",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "An accessible drop-button component.",
   "ooe": {
     "namespace": "global"

--- a/packages/drop-button/src/scss/styles.scss
+++ b/packages/drop-button/src/scss/styles.scss
@@ -107,6 +107,7 @@
       opacity: .75;
       height: rem(.605);
       margin-top: rem(.3);
+      max-width: 100%;
 
       @include bp(xs) {
         height: rem(.66);


### PR DESCRIPTION
# Description:
When used in certain flex containers in certain browsers, the ellipsis sprite seems to be able to escape from the bounds of the button element!  To combat this, we can forcibly limit the width of the sprite to 100% of its container (the button).

![image](https://github.com/PSU-OOE/components/assets/105240977/85ecef14-014f-4118-b319-47bfa0b07d22)

This should pretty much be a no-op except for these situations (first landing in Milestone 4...).

## Metadata
### Review environment Link
  https://developers.outreach.psu.edu/dropbutton-max-width/?p=viewall-molecules-drop-button