### PR TITLE
Make synchronous CTA tracking work even with complex html involved.

### DIFF
--- a/packages/cta-tracking/package.json
+++ b/packages/cta-tracking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/cta-tracking",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides analytics capabilities for calls to action.",
   "publishConfig": {
     "access": "public",

--- a/packages/cta-tracking/src/js/scripts.js
+++ b/packages/cta-tracking/src/js/scripts.js
@@ -12,7 +12,7 @@
       if (typeof window.dataLayer === 'object' && window.dataLayer?.push !== Array.prototype.push) {
         event.preventDefault();
 
-        const cta = event.target;
+        const cta = event.target.closest('[data-cta-track-sync]');
 
         const callbacks = [];
 

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.83",
+  "version": "1.0.84",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/utility/cta-tracking/cta-tracking-complex-cta-content.twig
+++ b/packages/patternlab/source/patterns/utility/cta-tracking/cta-tracking-complex-cta-content.twig
@@ -1,0 +1,1 @@
+<a href="#" data-cta-track-async data-cta-description="Plain Link with embedded html" data-cta-placement="Random Spot In Content">A <strong><em>plain</em> link</strong></a>


### PR DESCRIPTION
# Description:
There is a bug in the synchronous CTA tracking javascript that can be seen when a `[data-cta-track-sync]` element contains additional HTML markup.

![image](https://github.com/PSU-OOE/components/assets/105240977/ffc34209-718a-4ca9-b5db-a51f37bca381)


## Metadata
### Review environment Link
  https://developers.outreach.psu.edu/cta-tracking-complex-html/patterns/utility-cta-tracking/index.html?1689085749908 has an example with embedded HTML that can be clicked :-)