### PR TITLE
Add beaver-blue variant to the background container

### DIFF
--- a/packages/background-container/package.json
+++ b/packages/background-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/background-container",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Provides a container that supports background sprites.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/background-container/src/scss/_colors.scss
+++ b/packages/background-container/src/scss/_colors.scss
@@ -1,4 +1,5 @@
 $supported_colors: (
   'light-grey': $light-grey,
-  'primary-blue': $primary-blue
+  'primary-blue': $primary-blue,
+  'beaver-blue': $beaver-blue,
 );

--- a/packages/background-container/src/scss/_shield-bottomright.scss
+++ b/packages/background-container/src/scss/_shield-bottomright.scss
@@ -20,4 +20,8 @@
   &.bg--primary-blue .bg__sprite .sprite {
     opacity: .5;
   }
+
+  &.bg--beaver-blue .bg__sprite .sprite {
+    opacity: .22;
+  }
 }

--- a/packages/background-container/src/scss/_shield-left.scss
+++ b/packages/background-container/src/scss/_shield-left.scss
@@ -52,6 +52,10 @@
   &.bg--primary-blue .bg__sprite .sprite {
     opacity: .25;
   }
+
+  &.bg--beaver-blue .bg__sprite .sprite {
+    opacity: .22;
+  }
 }
 
 &.bg--shield-left.bg--narrow .bg__sprite .sprite {

--- a/packages/background-container/src/scss/_shield-program-page-at-a-glance.scss
+++ b/packages/background-container/src/scss/_shield-program-page-at-a-glance.scss
@@ -29,4 +29,8 @@
   &.bg--primary-blue .bg__sprite .sprite {
     opacity: .25;
   }
+
+  &.bg--beaver-blue .bg__sprite .sprite {
+    opacity: .22;
+  }
 }

--- a/packages/background-container/src/scss/_shield-program-page-banner-top.scss
+++ b/packages/background-container/src/scss/_shield-program-page-banner-top.scss
@@ -22,4 +22,8 @@
   &.bg--primary-blue .bg__sprite .sprite {
     opacity: .25;
   }
+
+  &.bg--beaver-blue .bg__sprite .sprite {
+    opacity: .22;
+  }
 }

--- a/packages/background-container/src/scss/_shield-right.scss
+++ b/packages/background-container/src/scss/_shield-right.scss
@@ -51,6 +51,10 @@
   &.bg--primary-blue .bg__sprite .sprite {
     opacity: .25;
   }
+
+  &.bg--beaver-blue .bg__sprite .sprite {
+    opacity: .22;
+  }
 }
 
 // Adjustments for narrow widths with right side shield

--- a/packages/background-container/src/scss/_shield-topleft-bottomright.scss
+++ b/packages/background-container/src/scss/_shield-topleft-bottomright.scss
@@ -72,4 +72,8 @@
   &.bg--primary-blue .bg__sprite .sprite {
     opacity: .25;
   }
+
+  &.bg--beaver-blue .bg__sprite .sprite {
+    opacity: .22;
+  }
 }

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.85",
+  "version": "1.0.86",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/background-container/_background-container.md
+++ b/packages/patternlab/source/patterns/molecules/background-container/_background-container.md
@@ -12,6 +12,7 @@
 |--------------|------------------------------------|
  | light-grey   | Displays a light-grey background   |
  | primary-blue | Displays a primary-blue background |
+ | beaver-blue  | Displays a beaver-blue background  |
 
 ## Background images
 | Image                      | Description                                                                                 |

--- a/packages/patternlab/source/patterns/molecules/background-container/background-container.twig
+++ b/packages/patternlab/source/patterns/molecules/background-container/background-container.twig
@@ -37,7 +37,7 @@
     .bg--primary-blue h3, .bg--primary-blue p { color: #fff !important; }
     .bg--beaver-blue h3, .bg--beaver-blue p { color: #fff !important; }
 </style>
-{% set colors = ['light-grey','primary-blue', 'beaver-blue'] %}
+{% set colors = ['light-grey', 'primary-blue', 'beaver-blue'] %}
 {% set backgrounds = ['shield:left', 'shield:right', 'shield:bottomright', 'shield:topleft-bottomright', 'shield:program-page-banner-top', 'shield:program-page-at-a-glance'] %}
 {% for color in colors %}
     {% for background in backgrounds %}

--- a/packages/patternlab/source/patterns/molecules/background-container/background-container.twig
+++ b/packages/patternlab/source/patterns/molecules/background-container/background-container.twig
@@ -33,8 +33,11 @@
       {{ tall_content }}
     </div>
 {% endset %}
-<style>.bg--primary-blue h3, .bg--primary-blue p { color: #fff !important; }</style>
-{% set colors = ['light-grey','primary-blue'] %}
+<style>
+    .bg--primary-blue h3, .bg--primary-blue p { color: #fff !important; }
+    .bg--beaver-blue h3, .bg--beaver-blue p { color: #fff !important; }
+</style>
+{% set colors = ['light-grey','primary-blue', 'beaver-blue'] %}
 {% set backgrounds = ['shield:left', 'shield:right', 'shield:bottomright', 'shield:topleft-bottomright', 'shield:program-page-banner-top', 'shield:program-page-at-a-glance'] %}
 {% for color in colors %}
     {% for background in backgrounds %}


### PR DESCRIPTION
# Description:
We need a new background color variant for milestone 4.

This adds `beaver-blue` as a color option, and updates the sprite opacity to 0.22 for this variation.

## Metadata

### Workfront Task Link
  Let's not expect one.

### Adobe XD Link
  https://xd.adobe.com/view/039fb73c-6d63-486a-b0b8-ec199209d4c7-56cc/screen/31088c24-ae06-4a52-bdf0-53d3019533ed/
### Review environment Link
  https://developers.outreach.psu.edu/background-container-new-color/?p=viewall-molecules-background-container