### PR TITLE
Intro form design changes and new color feature

### DIFF
--- a/packages/intro-form/intro-form.twig
+++ b/packages/intro-form/intro-form.twig
@@ -2,7 +2,7 @@
   {% set heading_level = 'span' %}
 {% endif %}
 
-{% if color not in ['primary-blue'] %}
+{% if color not in ['light-grey', 'primary-blue'] %}
   {% set color = 'light-grey' %}
 {% endif %}
 

--- a/packages/intro-form/intro-form.twig
+++ b/packages/intro-form/intro-form.twig
@@ -2,12 +2,21 @@
   {% set heading_level = 'span' %}
 {% endif %}
 
+{% if color not in ['primary-blue'] %}
+  {% set color = 'light-grey' %}
+{% endif %}
+
 {# @deprecated - the 'image' variable is removed in 2.0.0, use 'images' instead #}
 {% if image and not images %}
  {% set images = [image] %}
 {% endif %}
 
-<div class="intro-form">
+{% set classes = [
+  'intro-form',
+  color in ['primary-blue'] ? 'intro-form--' ~ color,
+] %}
+
+<div class="{{ classes|join(' ') }}">
   {% set bg_content %}
     <div class="intro-form__container">
       <div class="intro-form__first">
@@ -34,8 +43,7 @@
     </div>
   {% endset %}
   {% include '@molecules/background-container/background-container.twig' with {
-    classes: ['intro-form__background'],
-    color: 'light-grey',
+    color: color,
     background_image: 'shield:topleft-bottomright',
     content: bg_content,
   } only %}

--- a/packages/intro-form/intro-form.twig
+++ b/packages/intro-form/intro-form.twig
@@ -45,6 +45,7 @@
   {% include '@molecules/background-container/background-container.twig' with {
     color: color,
     background_image: 'shield:topleft-bottomright',
+    padding: 'small',
     content: bg_content,
   } only %}
 </div>

--- a/packages/intro-form/package.json
+++ b/packages/intro-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/intro-form",
-  "version": "1.3.2",
+  "version": "1.3.0",
   "description": "Provides a specialized container for presenting a form with accompanying intro content.",
   "publishConfig": {
     "access": "public",

--- a/packages/intro-form/package.json
+++ b/packages/intro-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/intro-form",
-  "version": "1.2.2",
+  "version": "1.3.2",
   "description": "Provides a specialized container for presenting a form with accompanying intro content.",
   "publishConfig": {
     "access": "public",

--- a/packages/intro-form/src/scss/styles.scss
+++ b/packages/intro-form/src/scss/styles.scss
@@ -30,7 +30,7 @@
       flex: 1;
       height: fit-content;
       margin-top: 0;
-      margin-bottom: 1rem;
+      margin-bottom: rem(1);
     }
   }
 

--- a/packages/intro-form/src/scss/styles.scss
+++ b/packages/intro-form/src/scss/styles.scss
@@ -30,6 +30,7 @@
       flex: 1;
       height: fit-content;
       margin-top: 0;
+      margin-bottom: 1rem;
     }
   }
 
@@ -130,10 +131,10 @@
   }
 
   &__second {
-    padding: 0 rem(2);
+    padding: 0 rem(2) rem(1) rem(2);
 
     @include bp(xs) {
-      padding: 0 rem(4);
+      padding: 0 rem(4) rem(1) rem(4);
     }
 
     @include bp(s) {

--- a/packages/intro-form/src/scss/styles.scss
+++ b/packages/intro-form/src/scss/styles.scss
@@ -3,36 +3,33 @@
 
 .intro-form {
 
-  @include bp(s) {
-    padding-top: rem(3);
-  }
-
-  &__background {
-    padding: 0;
-  }
-
   &__container {
     margin: auto;
     display: flex;
     flex-direction: column;
     gap: rem(3);
-    padding-bottom: rem(4);
 
     @include bp(s) {
       flex-direction: row;
       max-width: rem(97);
-      padding: 0 rem(4) rem(4) rem(4);
+      padding: 0 rem(4);
     }
   }
 
   &__first {
     position: relative;
 
+    margin-top: rem(-3);
+
+    @include bp(xs) {
+      margin-top: rem(-4);
+    }
+
     @include bp(s) {
-      box-shadow: rem(.1) rem(.2) $limestone;
+      box-shadow: rem(.1) rem(.2) rgba($nittany-navy, .4);
       flex: 1;
       height: fit-content;
-      margin-top: rem(-3);
+      margin-top: 0;
     }
   }
 
@@ -115,7 +112,7 @@
   &__description {
     background: $white;
     display: block;
-    box-shadow: rem(.1) rem(.2) $limestone;
+    box-shadow: rem(.1) rem(.2) rgba($nittany-navy, .4);
     padding: rem(2.5) rem(2);
     margin: rem(.4) rem(1) 0 rem(1);
 
@@ -141,8 +138,19 @@
 
     @include bp(s) {
       padding: 0;
-      margin-top: rem(3);
       flex: 1;
     }
+  }
+
+  &--primary-blue &__border {
+    @include bp(s) {
+      border-top: rem(.8) solid $beaver-blue;
+    }
+  }
+
+  &--primary-blue &__title {
+    background: $beaver-blue;
+    box-shadow: rem(-1.5) 0 0 $beaver-blue, rem(1.5) 0 0 $beaver-blue;
+
   }
 }

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.87",
+  "version": "1.0.88",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.85",
+  "version": "1.0.86",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/intro-form/intro-form~primary-blue.twig
+++ b/packages/patternlab/source/patterns/molecules/intro-form/intro-form~primary-blue.twig
@@ -1,0 +1,10 @@
+{# @TODO: Replace with a real form when base styles allow... #}
+{% include '@molecules/intro-form/intro-form.twig' with {
+  "color": "primary-blue",
+  "images": [
+    "<img src=\"https://via.placeholder.com/800x350\" alt=\"\">",
+  ],
+  "title": "Ready to Learn More?",
+  "description": "Get the resources you need to make informed decisions about your education. Request information on this program and other programs of interest by completing this form.",
+  "form": "<span style=\"color:white;\">Form placeholder</span>"
+} only %}


### PR DESCRIPTION
# Description:
- [x] Add primary blue variation to the intro form component.
- [x] Change padding and margins to eliminate top overflow and instead embrace more of what the `background-container` does off the shelf.  We still have some negative margin voodoo, but it's to a lesser extent.

Before:
![image](https://github.com/PSU-OOE/components/assets/105240977/85d9ab90-87a7-41aa-aea1-5e72d7525c10)

After:
![image](https://github.com/PSU-OOE/components/assets/105240977/d8a3dc45-faf0-40f7-9e10-3a6971d697ed)


## Metadata

### Workfront Task Link
  https://pennstateoutreach.my.workfront.com/task/64adbc110034079c12082edbce08dba3/overview

### Adobe XD Link
  https://xd.adobe.com/view/039fb73c-6d63-486a-b0b8-ec199209d4c7-56cc/

### Review environment Link
  https://developers.outreach.psu.edu/intro-form-update/?p=viewall-molecules-intro-form