### PR TITLE
Add once API binding

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/accordion",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Provides an accessible accordion implementation.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/accordion/src/js/scripts.js
+++ b/packages/accordion/src/js/scripts.js
@@ -4,7 +4,8 @@
  */
 ((cms) => {
   cms.attach('accordion', context => {
-    const accordions = context.querySelectorAll('.accordion');
+    const accordions = cms.once('accordion', '.accordion', context);
+
     accordions.forEach(accordion => {
       const button = accordion.querySelector('.accordion__button');
       const content = accordion.querySelector('.accordion__expandable-content');

--- a/packages/cta-tracking/package.json
+++ b/packages/cta-tracking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/cta-tracking",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provides analytics capabilities for calls to action.",
   "publishConfig": {
     "access": "public",

--- a/packages/cta-tracking/src/js/scripts.js
+++ b/packages/cta-tracking/src/js/scripts.js
@@ -1,6 +1,6 @@
 ((cms) => {
 
-  cms.attach('cta', context => {
+  cms.attach('cta-tracking', context => {
 
     // This click listener is assigned to a variable so that it can be
     // referenced from within itself.  When this listener is invoked, it
@@ -62,13 +62,13 @@
     };
 
     // Set up synchronous tracking.
-    const tracked_ctas_sync = context.querySelectorAll('[data-cta-track-sync]');
+    const tracked_ctas_sync = cms.once('cta-tracking', '[data-cta-track-sync]', context);
     tracked_ctas_sync.forEach(cta => {
       cta.addEventListener('click', synchronous_listener);
     });
 
     // Set up asynchronous tracking.
-    const tracked_ctas_async = context.querySelectorAll('[data-cta-track-async]');
+    const tracked_ctas_async = cms.once('cta-tracking', '[data-cta-track-async]', context);
     tracked_ctas_async.forEach(cta => {
       cta.addEventListener('click', () => {
         // Check to see if analytics.js is loaded.

--- a/packages/drop-button/package.json
+++ b/packages/drop-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/drop-button",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An accessible drop-button component.",
   "ooe": {
     "namespace": "global"

--- a/packages/drop-button/src/js/scripts.js
+++ b/packages/drop-button/src/js/scripts.js
@@ -1,6 +1,6 @@
 (cms => {
   cms.attach('dropbutton', context => {
-    const drop_buttons = context.querySelectorAll('.drop-button');
+    const drop_buttons = cms.once('dropbutton', '.drop-button', context);
     drop_buttons.forEach(drop_button => {
       const toggle = drop_button.querySelector('.drop-button__toggle');
 

--- a/packages/expandable-section/package.json
+++ b/packages/expandable-section/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/expandable-section",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Provides an expandable section implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/expandable-section/src/js/scripts.js
+++ b/packages/expandable-section/src/js/scripts.js
@@ -1,6 +1,6 @@
 (cms => {
     cms.attach('expandableSection', context => {
-      const elements = context.querySelectorAll('.expandable-section');
+      const elements = cms.once('expandableSection', '.expandable-section', context);
       elements.forEach(element => {
         const expand = element.querySelector('.expandable-section__expand');
         const content = element.querySelector('.expandable-section__content');

--- a/packages/flex-wrap-listener/package.json
+++ b/packages/flex-wrap-listener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/flex-wrap-listener",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides a javascript driven approach to listening for flex wrapping events.",
   "publishConfig": {
     "access": "public",

--- a/packages/flex-wrap-listener/src/js/scripts.js
+++ b/packages/flex-wrap-listener/src/js/scripts.js
@@ -189,7 +189,7 @@
       }
     });
 
-    const elements = context.querySelectorAll('[data-flex-wrap-aware]');
+    const elements = cms.once('flexWrapListener', '[data-flex-wrap-aware]', context)
     const init_first_item = new CustomEvent('flex-item-row-change', {
       detail: {
         old_row: null,

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/modal",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Provides a modal component.",
   "publishConfig": {
     "access": "public",

--- a/packages/modal/src/js/scripts.js
+++ b/packages/modal/src/js/scripts.js
@@ -1,7 +1,7 @@
 (cms => {
   cms.attach('modal', context => {
     // Variables
-    const modals = context.querySelectorAll(".modal");
+    const modals = cms.once('modal', '.modal', context);
 
     // Functions
     const showModal = (element) => {

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.88",
+  "version": "1.0.89",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/_meta/_head.twig
+++ b/packages/patternlab/source/_meta/_head.twig
@@ -6,9 +6,11 @@
     <script>
         const cms = {
             attach: (component, callback) => callback(document),
+            detach: (component, callback) => callback(document),
             announce: (text, priority) => { /* @todo: implement */ },
             vendor_dir: '/vendor',
             gtm_container_id: 'GTM-TXLS6TM',
+            once: (id, selector, context = document) => context.querySelectorAll(selector),
         };
     </script>
     {% include '@global/gtm/gtm.twig' %}

--- a/packages/polyfill-focus-visible/package.json
+++ b/packages/polyfill-focus-visible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/polyfill-focus-visible",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides a light-weight polyfill for :focus-visible.",
   "publishConfig": {
     "access": "public",

--- a/packages/polyfill-focus-visible/src/js/scripts.js
+++ b/packages/polyfill-focus-visible/src/js/scripts.js
@@ -4,6 +4,10 @@
  */
 (cms => {
   cms.attach('polyfillFocusVisible', context => {
+    if (context !== document) {
+      return;
+    }
+
     const style = document.createElement('style');
     document.head.appendChild(style);
     try {

--- a/packages/section-view-tracking/package.json
+++ b/packages/section-view-tracking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/section-view-tracking",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Provides a unified section view tracking algorithm.",
   "publishConfig": {
     "access": "public",

--- a/packages/section-view-tracking/src/js/scripts.js
+++ b/packages/section-view-tracking/src/js/scripts.js
@@ -28,7 +28,7 @@
       }
     }
 
-    const components = context.querySelectorAll('[data-interactive-component]');
+    const components = cms.once('sectionViewTracking', '[data-interactive-component]', context);
 
     components.forEach(component => {
       component.addEventListener('component:activate', e => {

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/tabs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Provides an accessible tabs implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/tabs/src/js/scripts.js
+++ b/packages/tabs/src/js/scripts.js
@@ -73,7 +73,7 @@
   }
 
   cms.attach('tabsList', context => {
-    const tabs_list_elements = context.querySelectorAll('.tabs-list');
+    const tabs_list_elements = cms.once('tabsList', '.tabs-list', context);
 
     tabs_list_elements.forEach(tabs_list_element => {
       const buttons = tabs_list_element.querySelectorAll('.tabs-list__button');
@@ -93,7 +93,7 @@
   });
 
   cms.attach('tabs', context => {
-    const tabs_elements = context.querySelectorAll('.tabs');
+    const tabs_elements = cms.once('tabs', '.tabs', context);
 
     tabs_elements.forEach(tabs_element => {
       const panels = tabs_element.querySelectorAll('.tabs__panel');


### PR DESCRIPTION
# Description:
Design system components should not assume that there will never been an overlap in attachment contexts.  Due to this, using a `once` mechanism (https://davidwalsh.name/javascript-once) is the solution.

We discovered that on the prospect site, certain user actions, such as AJAX page updates, could result in page section being partially rebuilt, and as such having behaviors re-attached.  This ultimately causes javascript events to fire more than once, and for some components to start to degrade pretty heavily.

Drupal ships with a `once` package out of the box.  Since Pattern Lab doesn't use AJAX, a "dumb" no-op example binding has been added.

## Metadata
Delete sections that are not relevant.

### Workfront Task Link
  https://pennstateoutreach.my.workfront.com/task/64c93f9a000cdb103ebc127c61e67b67/overview

### Review environment Link
  https://developers.outreach.psu.edu/once