### PR TITLE
Make nested backgrounds behave properly

### DIFF
--- a/packages/background-container/package.json
+++ b/packages/background-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/background-container",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Provides a container that supports background sprites.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/background-container/src/scss/_shield-bottomright.scss
+++ b/packages/background-container/src/scss/_shield-bottomright.scss
@@ -1,5 +1,5 @@
 &.bg--shield-bottomright {
-  .bg__sprite {
+  & > .bg__sprites > .bg__sprite {
     position: absolute;
     width: rem(8.6);
     height: rem(16.2);
@@ -17,11 +17,11 @@
     }
   }
 
-  &.bg--primary-blue .bg__sprite .sprite {
+  &.bg--primary-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .5;
   }
 
-  &.bg--beaver-blue .bg__sprite .sprite {
+  &.bg--beaver-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .22;
   }
 }

--- a/packages/background-container/src/scss/_shield-left.scss
+++ b/packages/background-container/src/scss/_shield-left.scss
@@ -1,5 +1,5 @@
 &.bg--shield-left {
-  .bg__sprite .sprite {
+  & > .bg__sprites > .bg__sprite .sprite {
     position: absolute;
     height: auto;
     width: rem(70);
@@ -49,16 +49,16 @@
     }
   }
 
-  &.bg--primary-blue .bg__sprite .sprite {
+  &.bg--primary-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .25;
   }
 
-  &.bg--beaver-blue .bg__sprite .sprite {
+  &.bg--beaver-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .22;
   }
 }
 
-&.bg--shield-left.bg--narrow .bg__sprite .sprite {
+&.bg--shield-left.bg--narrow > .bg__sprites > .bg__sprite .sprite {
   @supports (container-type: inline-size ) {
 
     //noinspection CssInvalidAtRule

--- a/packages/background-container/src/scss/_shield-program-page-at-a-glance.scss
+++ b/packages/background-container/src/scss/_shield-program-page-at-a-glance.scss
@@ -1,5 +1,5 @@
 &.bg--shield-program-page-at-a-glance {
-  .bg__sprite .sprite {
+  & > .bg__sprites > .bg__sprite .sprite {
     position: absolute;
     width: rem(53.2);
     height: auto;
@@ -26,11 +26,11 @@
     }
   }
 
-  &.bg--primary-blue .bg__sprite .sprite {
+  &.bg--primary-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .25;
   }
 
-  &.bg--beaver-blue .bg__sprite .sprite {
+  &.bg--beaver-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .22;
   }
 }

--- a/packages/background-container/src/scss/_shield-program-page-banner-top.scss
+++ b/packages/background-container/src/scss/_shield-program-page-banner-top.scss
@@ -1,5 +1,5 @@
 &.bg--shield-program-page-banner-top {
-  .bg__sprite .sprite {
+  & > .bg__sprites > .bg__sprite .sprite {
     position: absolute;
     width: rem(53.2);
     height: auto;
@@ -19,11 +19,11 @@
       }
     }
   }
-  &.bg--primary-blue .bg__sprite .sprite {
+  &.bg--primary-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .25;
   }
 
-  &.bg--beaver-blue .bg__sprite .sprite {
+  &.bg--beaver-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .22;
   }
 }

--- a/packages/background-container/src/scss/_shield-right.scss
+++ b/packages/background-container/src/scss/_shield-right.scss
@@ -1,5 +1,5 @@
 &.bg--shield-right {
-  .bg__sprite .sprite {
+  & > .bg__sprites > .bg__sprite .sprite {
     position: absolute;
     height: auto;
     width: rem(70);
@@ -48,17 +48,18 @@
       }
     }
   }
-  &.bg--primary-blue .bg__sprite .sprite {
+
+  &.bg--primary-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .25;
   }
 
-  &.bg--beaver-blue .bg__sprite .sprite {
+  &.bg--beaver-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .22;
   }
 }
 
 // Adjustments for narrow widths with right side shield
-&.bg--shield-right.bg--narrow .bg__sprite .sprite {
+&.bg--shield-right.bg--narrow > .bg__sprites > .bg__sprite .sprite {
 
   //noinspection CssUnknownProperty
   @supports (container-type: inline-size ) {

--- a/packages/background-container/src/scss/_shield-topleft-bottomright.scss
+++ b/packages/background-container/src/scss/_shield-topleft-bottomright.scss
@@ -1,5 +1,5 @@
 &.bg--shield-topleft-bottomright {
-  .bg__sprite .sprite {
+  & > .bg__sprites > .bg__sprite .sprite {
     position: absolute;
     height: auto;
     display: none;
@@ -10,7 +10,7 @@
     }
   }
 
-  .bg__sprite--1 .sprite {
+  & > .bg__sprites > .bg__sprite--1 .sprite {
     width: rem(53.2);
     left: rem(-30);
     top: rem(-40);
@@ -38,7 +38,7 @@
       }
     }
   }
-  .bg__sprite--2 .sprite {
+  & > .bg__sprites > .bg__sprite--2 .sprite {
     width: rem(53.2);
     right: rem(-32);
     bottom: rem(-46);
@@ -69,11 +69,11 @@
     }
   }
 
-  &.bg--primary-blue .bg__sprite .sprite {
+  &.bg--primary-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .25;
   }
 
-  &.bg--beaver-blue .bg__sprite .sprite {
+  &.bg--beaver-blue > .bg__sprites > .bg__sprite .sprite {
     opacity: .22;
   }
 }

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.90",
+  "version": "1.0.91",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/background-container/background-container~nested.twig
+++ b/packages/patternlab/source/patterns/molecules/background-container/background-container~nested.twig
@@ -1,0 +1,33 @@
+{% set content %}
+  <div style="padding:10rem;">
+    I'm in pretty deep here...
+  </div>
+{% endset %}
+
+{% set third_generation %}
+  <div style="padding:10rem;">
+    {% include '@molecules/background-container/background-container.twig' with {
+        color: 'beaver-blue',
+        background_image: 'shield:topleft-bottomright',
+        content: content,
+      } only %}
+  </div>
+{% endset %}
+
+{% set second_generation %}
+  <div style="padding:10rem;">
+    {% include '@molecules/background-container/background-container.twig' with {
+      color: 'primary-blue',
+      background_image: 'shield:right',
+      content: third_generation,
+    } only %}
+  </div>
+{% endset %}
+
+<div style="text-align:center; color:#fff">
+  {% include '@molecules/background-container/background-container.twig' with {
+    color: 'light-grey',
+    background_image: 'shield:left',
+    content: second_generation,
+  } only %}
+</div>


### PR DESCRIPTION
# Description:
This change adds some direct descendant selectors into the mix to prevent different generations of nested backgrounds from blending properties.  The generated CSS is more complex, but ultimately should make nesting background containers possible.

I've also added a nested example.

## Metadata

### Workfront Task Link
  https://pennstateoutreach.my.workfront.com/task/64d4043400287f71afd913de5b899dd9/overview
### Adobe XD Link
  N/A
### Review environment Link
  https://developers.outreach.psu.edu/bg-container-fixes/patterns/molecules-background-container/index.html#molecules-background-container-nested