### PR TITLE
Cta font weight + auto-contrasting update

### DIFF
--- a/packages/cta/cta-block.twig
+++ b/packages/cta/cta-block.twig
@@ -8,6 +8,10 @@
 {% if compact %}
   {% set classes = classes|merge(['cta-block--compact']) %}
 {% endif %}
+{% if font_weight in ['bold'] %}
+  {% set classes = classes|merge(['cta-block--' ~ font_weight]) %}
+{% endif %}
+
 <a
   class="{{ classes|join(' ') }}"
   href="{{ url }}"

--- a/packages/cta/package.json
+++ b/packages/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/cta",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Provides a CTA button.",
   "publishConfig": {
     "access": "public",

--- a/packages/cta/src/scss/_cta-block.scss
+++ b/packages/cta/src/scss/_cta-block.scss
@@ -179,7 +179,7 @@
     box-shadow: rem(.1) rem(.1) 0 0 rgba($nittany-navy, .5);
   }
 
-  &:is(.bg--light-grey *) {
+  &:is(.bg--light-grey *, .bg--primary-blue *, .bg--beaver-blue *) {
     --cta-block-expand-background-color: var(--cta-block-expand-background-color-light);
   }
 }

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.90",
+  "version": "1.0.91",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/atoms/cta/cta~bold.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~bold.twig
@@ -1,0 +1,5 @@
+{% include '@atoms/cta/cta-block.twig' with {
+  label: 'Begin Test',
+  url: '#',
+  font_weight: 'bold',
+} only %}

--- a/packages/patternlab/source/patterns/atoms/cta/cta~color-expand-reversed.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~color-expand-reversed.twig
@@ -1,13 +1,27 @@
 {% set cta %}
-  {% include '@atoms/cta/cta-block.twig' with {
-    label: 'Expand items',
-    url: '#',
-    color: 'expand',
-  } only %}
+  <div style="padding: 0 4rem">
+    {% include '@atoms/cta/cta-block.twig' with {
+      label: 'Expand items',
+      url: '#',
+      color: 'expand',
+    } only %}
+  </div>
 {% endset %}
 
 {% include '@molecules/background-container/background-container.twig' with {
   color: 'light-grey',
   background_image: 'shield:right',
+  content: cta
+} only %}
+
+{% include '@molecules/background-container/background-container.twig' with {
+  color: 'primary-blue',
+  background_image: 'shield:right',
+  content: cta
+} only %}
+
+{% include '@molecules/background-container/background-container.twig' with {
+  color: 'beaver-blue',
+  background_image: 'shield:topleft-bottomright',
   content: cta
 } only %}


### PR DESCRIPTION
# Description:
Presently, the expand CTA variant only automatically contrasts itself on light-grey backgrounds.  This contrasting also has to work with primary-blue (and beaver-blue, because why not?) backgrounds now.

We also need to expose a font-weight modifier for all CTA variants for milestone 4.  This modifier should take a single optional parameter, bold, which applies the cta-block--bold class.

Luckily, we already had a `cta-block--bold` modifier in the CSS!  This happy accident is already in use on campaign pages.  Look at us thinking forward.

## Metadata
Delete sections that are not relevant.

### Workfront Task Link
  https://pennstateoutreach.my.workfront.com/task/64d4045600288d11320977cecb4131cc/overview
### Adobe XD Link
  https://xd.adobe.com/view/98d5236c-b8ef-45c6-af92-3fce077161d2-cd86/
### Review environment Link
  https://developers.outreach.psu.edu/cta-font-weight/?p=viewall-atoms-cta