### PR TITLE
Add vspace modifier to headings

### DIFF
--- a/packages/heading/heading.twig
+++ b/packages/heading/heading.twig
@@ -6,6 +6,7 @@
 {% set allowed_colors = ['neutral']  %}
 {% set allowed_sizes = ['xlarge', 'large', 'medium', 'small', 'xsmall'] %}
 {% set allowed_alignments = ['left', 'center', 'right'] %}
+{% set allowed_vspaces = ['small', 'large'] %}
 
 {% if level in allowed_levels and content is not empty %}
 
@@ -14,7 +15,8 @@
     color in allowed_colors ? 'heading--' ~ color,
     size in allowed_sizes ? 'heading--' ~ size,
     flush ? 'heading--flush',
-    align in allowed_alignments ? 'heading--align-' ~ align
+    align in allowed_alignments ? 'heading--align-' ~ align,
+    vspace in allowed_vspaces ? 'heading--vspace-' ~ vspace,
   ]) | filter(class => class is not empty) %}
 {% apply spaceless %}
   <h{{ level }}{% if classes %} class="{{ classes|join(' ') }}"{% endif %}>{{ content }}</h{{ level }}>

--- a/packages/heading/package.json
+++ b/packages/heading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/heading",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Provides a heading implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/heading/src/scss/styles.scss
+++ b/packages/heading/src/scss/styles.scss
@@ -88,6 +88,14 @@ h5,
   text-align: center;
 }
 
+.heading--vspace-small {
+  margin-bottom: rem(1);
+}
+
+.heading--vspace-large {
+  margin-bottom: rem(3);
+}
+
 // @TODO: Eventually, get away from defining font sizing in here.
 .heading--hr {
   display: flex;

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.91",
+  "version": "1.0.92",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/atoms/heading/heading~vspace-large.twig
+++ b/packages/patternlab/source/patterns/atoms/heading/heading~vspace-large.twig
@@ -1,0 +1,5 @@
+{% include '@atoms/heading/heading.twig' with {
+  content: "The quick brown fox <span class=\"text--contrasting\">jumps</span> over the lazy dog",
+  vspace: 'large',
+} only %}
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>

--- a/packages/patternlab/source/patterns/atoms/heading/heading~vspace-small.twig
+++ b/packages/patternlab/source/patterns/atoms/heading/heading~vspace-small.twig
@@ -1,0 +1,5 @@
+{% include '@atoms/heading/heading.twig' with {
+  content: "The quick brown fox <span class=\"text--contrasting\">jumps</span> over the lazy dog",
+  vspace: 'small',
+} only %}
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>


### PR DESCRIPTION
# Description:
This change did not originate with design.  It may not even be correct for all I know.  Greg has taken over program page milestone 4 design decisions while Matt Ryan is on vacation.

Add a new backwards-compatible modifier to the heading component: `vspace`.  `vspace` will accept either `'small'` or `'large'` and will produce either a `1rem` or `3rem` `margin-bottom`, respectively.  If omitted, the default `2rem` applies.

## Metadata

### Workfront Task Link
  TBD
### Adobe XD Link
  N/A
### Review environment Link
  http://developers.outreach.psu.edu/heading-vspace-mods/?p=all