### PR TITLE
Fix a rem deprecation that caused a compile error in the packaging process

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/accordion",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Provides an accessible accordion implementation.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/accordion/src/scss/styles.scss
+++ b/packages/accordion/src/scss/styles.scss
@@ -80,7 +80,7 @@
     .accordion__label--label-underline {
       color: $primary-blue;
       text-decoration-color: $primary-blue;
-      text-decoration-thickness: rem(.1);
+      text-decoration-thickness: _rem(.1);
       text-decoration-line: underline;
       text-decoration-style: dotted;
       text-underline-offset: .2em;


### PR DESCRIPTION
# Description:
There's one more instance of the now reserved `rem` keyword in the monorepo now.  Accordions exploded, so let's fix them.