### PR TITLE
Add optional toc label parameter to accordions

### DIFF
--- a/packages/accordion/accordion.twig
+++ b/packages/accordion/accordion.twig
@@ -37,7 +37,7 @@
     {% set expandable_content_classes = expandable_content_classes|merge(['accordion__expandable-content--indent-content']) %}
   {% endif %}
 
-  <div class="{{ expandable_content_classes|join(' ') }}" id="{{ id }}" {% if not expanded %} style="height:0; overflow:hidden"{% endif %}>
+  <div class="{{ expandable_content_classes|join(' ') }}" id="{{ id }}"{% if toc_label %} data-toc-label="{{ toc_label }}"{% endif %} {% if not expanded %} style="height:0; overflow:hidden"{% endif %}>
     {{ expandable_content }}
   </div>
 </div>

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/accordion",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "Provides an accessible accordion implementation.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.94",
+  "version": "1.0.95",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/accordion/accordion~with-toc-label.twig
+++ b/packages/patternlab/source/patterns/molecules/accordion/accordion~with-toc-label.twig
@@ -1,6 +1,6 @@
 {% include '@molecules/accordion/accordion.twig' with {
   "id": "accordion-default",
-  "label": "Accordion item (default)",
+  "label": "Accordion item (with toc label)",
   "expandable_content": "This is the accordion content.",
-  "toc_label": "Accordion item (default)",
+  "toc_label": "Accordion item",
 } only %}

--- a/packages/patternlab/source/patterns/molecules/accordion/accordion~with-toc-label.twig
+++ b/packages/patternlab/source/patterns/molecules/accordion/accordion~with-toc-label.twig
@@ -1,0 +1,6 @@
+{% include '@molecules/accordion/accordion.twig' with {
+  "id": "accordion-default",
+  "label": "Accordion item (default)",
+  "expandable_content": "This is the accordion content.",
+  "toc_label": "Accordion item (default)",
+} only %}


### PR DESCRIPTION
# Description:
Desire has been expressed to include accordions in table of contents implementations.  This change adds an optional "toc_label" that can be applied to accordions.  It just adds a `data-toc-label` attribute.

## Metadata
### Workfront Task Link
  https://pennstateoutreach.my.workfront.com/task/64f08a34001eb6e61ba1034a516ca826/overview
### Review environment Link
  https://developers.outreach.psu.edu/accordion-toc-label/?p=viewall-molecules-accordion