### PR TITLE
Prevent absolutely positioned child elements from messing up overflow rules

### DIFF
--- a/packages/expandable-section/package.json
+++ b/packages/expandable-section/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/expandable-section",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Provides an expandable section implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/expandable-section/src/scss/styles.scss
+++ b/packages/expandable-section/src/scss/styles.scss
@@ -13,6 +13,7 @@
     transition-property: height, margin-bottom, visibility;
     transition-timing-function: ease-in-out;
     margin-bottom: 0;
+    position: relative;
   }
 
   &__expand[aria-expanded="true"] + .expandable-section__content {

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "1.0.96",
+  "version": "1.0.97",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/organisms/expandable-section/expandable-section~overflow-bug.twig
+++ b/packages/patternlab/source/patterns/organisms/expandable-section/expandable-section~overflow-bug.twig
@@ -1,0 +1,71 @@
+{% set bio_1 %}
+  {% include '@organisms/bio/bio.twig' with {
+    title: {
+      level: 2,
+      content: 'Thomas T. Amlie',
+      color: 'neutral',
+    },
+    profile_photo: '<img src="https://via.placeholder.com/130x130" alt="test">',
+    job_title: 'Condimentum id venenatis a condimentum vitae',
+    credentials: [
+      { icon: 'fas-graduation-cap', icon_alt: 'Degree', text: 'Ph.D., Accounting, University of Maryland'},
+      { icon: 'fas-graduation-cap', icon_alt: 'Degree', text: 'MBA, University of Maryland'},
+    ],
+    content: '<p>Dr. Thomas T. Amlie\'s teaching interests are in the area of financial accounting and reporting. His research interests center on the proper disclosure of accounting information, the assumptions underlying that accounting information, and the effects of those assumptions on business decisions and reporting.</p>',
+
+  } only %}
+{% endset %}
+{% set bio_2 %}
+  {% include '@organisms/bio/bio.twig' with {
+    title: {
+      level: 2,
+      content: 'Janet Duck',
+      color: 'neutral',
+    },
+    profile_photo: '<img src="https://via.placeholder.com/130x130" alt="test">',
+    job_title: 'Faculty Chair, Online MBA',
+    credentials: [
+      { icon: 'fas-graduation-cap', icon_alt: 'Degree', text: 'MBA, Lebanon Valley College'},
+      { icon: 'fas-graduation-cap', icon_alt: 'Degree', text: 'B.S., Business Administration, Slippery Rock University'},
+      { icon: 'fas-certificate', icon_alt: 'Credential', text: 'Ph.D., Workforce Development, Penn State'},
+    ],
+    content: '<p>Dr. Janet Duck has more than 15 years of teaching, authoring, and designing experience in online graduate environments. She teaches courses in organizational change management, leadership communication, organizational development and intervention, and team performance. Additionally, Dr. Duck serves as the faculty lead for the Professional Graduate Portfolio (PGP) at the Smeal College of Business, where she facilitates data-driven course design for the graduate business population. She has received the Outstanding Faculty award for the iMBA. She has more than 15 years of industry experience in organizational change and development in both domestic and international markets. Dr. Duck\'s work in online teaching has been highlighted in The New York Times and Delta Sky Magazine.</p>',
+    link: {
+      url: '#',
+      title: 'See Janet\'s full profile',
+    },
+  } only %}
+{% endset %}
+{% set bio_3 %}
+  {% include '@organisms/bio/bio.twig' with {
+    title: {
+      level: 2,
+      content: 'John Cameron',
+      color: 'neutral',
+    },
+    profile_photo: '<img src="https://via.placeholder.com/130x130" alt="test">',
+    credentials: [
+      { icon: 'fas-graduation-cap', icon_alt: 'Degree', text: 'J.D., Widener University School of Law'},
+      { icon: 'fas-graduation-cap', icon_alt: 'Degree', text: 'LLM, Corporation Law, New York University School of Law'},
+      { icon: 'fas-graduation-cap', icon_alt: 'Degree', text: 'MBA, Temple University'},
+      { icon: 'fas-graduation-cap', icon_alt: 'Degree', text: 'B.A., University of Pittsburgh'},
+    ],
+    content: '<p>John C. Cameron, associate professor of management and organization, held corporate positions in health care administration and corporate law. He is admitted to practice law in Pennsylvania, Maryland, and New Jersey. Currently he serves as the co-chair of the Pennsylvania Bar Association Health Care Law Committee. Mr. Cameron teaches courses in leadership development, business ethics, bioscience management and negotiations. His research interests are in the areas of corporate governance, bioethics, leadership, and regulatory compliance.</p>',
+
+  } only %}
+{% endset %}
+
+{% set bio_collection %}
+  {% include '@blocks/bio-collection/bio-collection.twig' with {
+    bios: [bio_1, bio_2, bio_3]
+  } only %}
+{% endset %}
+
+{% include '@organisms/expandable-section/expandable-section.twig' with {
+  id: 'minors',
+  toc_label: 'Minors',
+  intro: "<div class=\"wysiwyg\"><h2 class=\"heading--neutral heading--flush\">Minors</h2><p>Penn State World Campus students can optionally supplement their degree with a minor.</p></div>",
+  expand_label: "View Minors",
+  content: bio_collection,
+  collapse_label: "Close Minors"
+} only %}

--- a/packages/patternlab/source/patterns/organisms/expandable-section/expandable-section~overflow-bug.twig
+++ b/packages/patternlab/source/patterns/organisms/expandable-section/expandable-section~overflow-bug.twig
@@ -64,8 +64,8 @@
 {% include '@organisms/expandable-section/expandable-section.twig' with {
   id: 'minors',
   toc_label: 'Minors',
-  intro: "<div class=\"wysiwyg\"><h2 class=\"heading--neutral heading--flush\">Minors</h2><p>Penn State World Campus students can optionally supplement their degree with a minor.</p></div>",
-  expand_label: "View Minors",
+  intro: "<div class=\"wysiwyg\"><h2 class=\"heading--neutral heading--flush\"><span class=\"text--contrasting\">World Class</span> Faculty</h2></div>",
+  expand_label: "Meet the Team",
   content: bio_collection,
-  collapse_label: "Close Minors"
+  collapse_label: "Close Team"
 } only %}


### PR DESCRIPTION
# Description:
Expandable sections' overflow rules may be broken by absolutely positioned child elements.  To remedy this, we need to set `position: relative` on the container that can contain absolutely positioned elements, as a firewall of sorts.

## Metadata

### Workfront Task Link
  https://pennstateoutreach.my.workfront.com/task/6500b552002ccb535b48d99c15d802fd/overview

### Review environment Link
  https://developers.outreach.psu.edu/expandable-section-overflow/?p=viewall-organisms-expandable-section