### PR TITLE
Adjust font weight for page title

### DIFF
--- a/packages/page-title/package.json
+++ b/packages/page-title/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/page-title",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides a page title component.",
   "publishConfig": {
     "access": "public",

--- a/packages/page-title/src/scss/styles.scss
+++ b/packages/page-title/src/scss/styles.scss
@@ -16,6 +16,7 @@
     font-family: var(--font-family--display);
     font-size: var(--font-size--xlarge);
     line-height: var(--line-height--2xsnug);
+    font-weight: var(--font-weight--medium);
   }
 
   &__subtitle-after {


### PR DESCRIPTION
# Description:
There was an error in the original specification.  Subtitle font weights must not inherit from the surrounding context.

## Metadata
### Review environment Link
  https://developers.outreach.psu.edu/page-title-subtitle-weight/?p=viewall-molecules-page-title