### PR TITLE
Move the field stuff

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/base",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "The base styles for the OOE design system.",
   "ooe": {
     "namespace": "global"

--- a/packages/base/src/scss/_fields.scss
+++ b/packages/base/src/scss/_fields.scss
@@ -1,8 +1,0 @@
-// @TODO: Move me to the prospect site and deprecate me.
-.field {
-  margin-bottom: _rem(2);
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-}

--- a/packages/base/src/scss/styles.scss
+++ b/packages/base/src/scss/styles.scss
@@ -128,7 +128,6 @@ footer {
 @import 'blockquote';
 @import 'figure';
 @import "buttons";
-@import "fields";
 @import "tables";
 @import "forms";
 


### PR DESCRIPTION
# Description:
We had a todo item to move the field stuff, which isn't relevant to the design system.  It's a drupalism and doesn't belong in here.

This will have a companion task on the prospect site to restore this over there for now, until no more references exist.