### PR TITLE
Add webfonts to the critical render path

### DIFF
--- a/packages/webfonts/package.json
+++ b/packages/webfonts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/webfonts",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Contains the webfonts of the OOE design system",
   "homepage": "https://github.com/PSU-OOE/monorepo-dev#readme",
   "ooe": {

--- a/packages/webfonts/webfonts.twig
+++ b/packages/webfonts/webfonts.twig
@@ -1,1 +1,2 @@
-<link href="https://use.typekit.net/lwk5qvj.css" rel="preload" as="style" onload="this.rel='stylesheet'">
+<link rel="prefetch" href="//p.typekit.net/p.css?s=1&k=llt5zza&ht=tk&f=139.140.169.173.174.175.176.11005.11006.11007&a=36957641&app=typekit&e=css">
+<link href="//use.typekit.net/llt5zza.css" rel="stylesheet">

--- a/packages/webfonts/webfonts.twig
+++ b/packages/webfonts/webfonts.twig
@@ -1,2 +1,2 @@
-<link rel="prefetch" href="//p.typekit.net/p.css?s=1&k=llt5zza&ht=tk&f=139.140.169.173.174.175.176.11005.11006.11007&a=36957641&app=typekit&e=css">
+<link rel="preload" as="style" href="//p.typekit.net/p.css?s=1&k=llt5zza&ht=tk&f=139.140.169.173.174.175.176.11005.11006.11007&a=36957641&app=typekit&e=css">
 <link href="//use.typekit.net/llt5zza.css" rel="stylesheet">

--- a/packages/webfonts/webfonts.twig
+++ b/packages/webfonts/webfonts.twig
@@ -1,2 +1,2 @@
-<link rel="preload" as="style" href="//p.typekit.net/p.css?s=1&k=llt5zza&ht=tk&f=139.140.169.173.174.175.176.11005.11006.11007&a=36957641&app=typekit&e=css">
-<link href="//use.typekit.net/llt5zza.css" rel="stylesheet">
+<link rel="preload" as="style" href="https://p.typekit.net/p.css?s=1&k=llt5zza&ht=tk&f=139.140.169.173.174.175.176.11005.11006.11007&a=36957641&app=typekit&e=css">
+<link href="https://use.typekit.net/llt5zza.css" rel="stylesheet">


### PR DESCRIPTION
# Description:
Design has decided that we must add webfonts back to the critical render path.

There's a slight ray of hope in that we may be able to get legal authorization in the future to reverse-proxy cache the Adobe hosted CSS and serve it inline in the document response, as is best practice outlined by Google.

To _potentially_ help to alleviate even more first paint regressions, I've added a preload directive that will start a parallel download of a bloat file that the Adobe font stack unconditionally loads...

## Metadata
### Review environment Link
  https://developers.outreach.psu.edu/render-blocking-webfonts/?p=all