### PR TITLE
Prevent randomization from happening if the browser is being controlled by automation software

### DIFF
--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/random-item/package.json
+++ b/packages/random-item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/random-item",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provides a simple client-side randomization mechanism.",
   "publishConfig": {
     "access": "public",

--- a/packages/random-item/random-item.twig
+++ b/packages/random-item/random-item.twig
@@ -4,7 +4,7 @@
     (() => {
       const items = {{ items|json_encode()|raw }};
       if (items) {
-        document.querySelector('#{{ identifier }}').outerHTML = items[~~(Math.random() * items.length)];
+        document.querySelector('#{{ identifier }}').outerHTML = navigator.webdriver ? items[0] : items[~~(Math.random() * items.length)];
       }
     })();
   </script>


### PR DESCRIPTION
# Description:
Include a lightweight check to only randomize items if the browser isn't being controlled by automated tooling.

Read more about the webdriver property of the Navigator interface here: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/webdriver.

## Metadata
### Review environment Link
  https://developers.outreach.psu.edu/211-add-mechanism-to-stop-randomization-if-automated-testing-is-being-applied/?p=viewall-organisms-random-item -- Run this test to verify that automated tooling is no longer randomized: https://app.ghostinspector.com/tests/65c39604f59aa2b4f31208d5