### PR TITLE
230 add type button to modal close button

### DIFF
--- a/packages/modal/modal.twig
+++ b/packages/modal/modal.twig
@@ -2,7 +2,7 @@
   <div class="modal__overlay">
     <div class="modal__container" role="dialog" aria-modal="true">
       <h2 class="modal__title visually-hidden" tabindex="-1">{{ title }}</h2>
-      <button class="modal__close" aria-label="Close">
+      <button type="button" class="modal__close" aria-label="Close">
         {% include '@psu-ooe/sprite/sprite.twig' with { name: 'fa-times' } %}
       </button>
       <span class="modal__content">

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/modal",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Provides a modal component.",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
# Description:
Add `type="button"` to the modal component close button to prevent modals from unintentionally submitting forms when a modal nested in a form is closed.

## Metadata

### Review environment Link
  https://developers.outreach.psu.edu/230-add-type-button-to-modal-close-button/?p=viewall-molecules-modal