### PR TITLE
Add the concept of "preferred colors" to CTA's

### DIFF
--- a/packages/cta/cta-block.twig
+++ b/packages/cta/cta-block.twig
@@ -1,11 +1,11 @@
 {# @TODO: Remove backwards-compatibility layer in 3.0.0 #}
-{% if not color_dark %}
+{% if not color_on_dark %}
   {% if color == 'color-keystone' %}
-    {% set color_dark = 'color-keystone' %}
+    {% set color_on_dark = 'color-keystone' %}
   {% elseif color == 'light-blue' %}
-    {% set color_dark = 'light-blue' %}
+    {% set color_on_dark = 'light-blue' %}
   {% else %}
-    {% set color_dark = 'reversed' %}
+    {% set color_on_dark = 'reversed' %}
     {% if color == 'reversed' %}
       {# Continue to support reversed-on-light for old uses. #}
       {% set reversed_legacy = true %}
@@ -16,7 +16,7 @@
 {% set classes = [
   'cta-block',
   reversed_legacy or color in ['alt', 'color-keystone', 'hollow-solid', 'hollow-dotted', 'light-blue', 'expand', 'expand-reversed'] ? 'cta-block--' ~ color,
-  color_dark in ['color-keystone', 'reversed', 'light-blue'] ? 'cta-block--on-dark-' ~ color_dark,
+  color_on_dark in ['color-keystone', 'reversed', 'light-blue'] ? 'cta-block--on-dark-' ~ color_on_dark,
   expand_to_fit ? 'cta-block--expand-to-fit',
   font_weight in ['bold'] ? 'cta-block--' ~ font_weight,
   size in ['xcompact', 'compact', 'compact-responsive'] ? 'cta-block--' ~ size,

--- a/packages/cta/cta-block.twig
+++ b/packages/cta/cta-block.twig
@@ -1,3 +1,14 @@
+{# @TODO: Remove backwards-compatibility layer in 3.0.0 #}
+{% if not color_dark %}
+  {% if color == 'reversed' %}
+    {% set color_dark = 'reversed' %}
+  {% elseif color == 'color-keystone' %}
+    {% set color_dark = 'color-keystone' %}
+  {% elseif color == 'light-blue' %}
+    {% set color_dark = 'light-blue' %}
+  {% endif %}
+{% endif %}
+
 {% set classes = [
   'cta-block',
   color in ['alt', 'color-keystone', 'hollow-solid', 'hollow-dotted', 'light-blue', 'expand', 'expand-reversed']? 'cta-block--' ~ color,

--- a/packages/cta/cta-block.twig
+++ b/packages/cta/cta-block.twig
@@ -1,7 +1,4 @@
 {# @TODO: Remove backwards-compatibility layer in 3.0.0 #}
-{% if not color_dark and color == 'reversed' %}
-  {% set reversed_legacy = true %}
-{% endif %}
 {% if not color_dark %}
   {% if color == 'color-keystone' %}
     {% set color_dark = 'color-keystone' %}
@@ -9,6 +6,10 @@
     {% set color_dark = 'light-blue' %}
   {% else %}
     {% set color_dark = 'reversed' %}
+    {% if color == 'reversed' %}
+      {# Continue to support reversed-on-light for old uses. #}
+      {% set reversed_legacy = true %}
+    {% endif %}
   {% endif %}
 {% endif %}
 

--- a/packages/cta/cta-block.twig
+++ b/packages/cta/cta-block.twig
@@ -4,6 +4,11 @@
 {% endif %}
 {% if color %}
   {% set classes = classes|merge(['cta-block--' ~ color]) %}
+{% elseif color_light or color_dark %}
+  {% set classes = classes|merge([
+    'cta-block--on-light-' ~ color_light,
+    'cta-block--on-dark-' ~ color_dark,
+  ]) %}
 {% endif %}
 {% if font_weight in ['bold'] %}
   {% set classes = classes|merge(['cta-block--' ~ font_weight]) %}

--- a/packages/cta/cta-block.twig
+++ b/packages/cta/cta-block.twig
@@ -6,8 +6,8 @@
   {% set classes = classes|merge(['cta-block--' ~ color]) %}
 {% elseif color_light or color_dark %}
   {% set classes = classes|merge([
-    'cta-block--on-light-' ~ color_light,
-    'cta-block--on-dark-' ~ color_dark,
+    color_light ? 'cta-block--on-light-' ~ color_light,
+    color_dark ? 'cta-block--on-dark-' ~ color_dark,
   ]) %}
 {% endif %}
 {% if font_weight in ['bold'] %}

--- a/packages/cta/cta-block.twig
+++ b/packages/cta/cta-block.twig
@@ -1,21 +1,12 @@
-{% set classes = ['cta-block'] %}
-{% if expand_to_fit %}
-  {% set classes = classes|merge(['cta-block--expand-to-fit']) %}
-{% endif %}
-{% if color %}
-  {% set classes = classes|merge(['cta-block--' ~ color]) %}
-{% elseif color_light or color_dark %}
-  {% set classes = classes|merge([
-    color_light ? 'cta-block--on-light-' ~ color_light,
-    color_dark ? 'cta-block--on-dark-' ~ color_dark,
-  ]) %}
-{% endif %}
-{% if font_weight in ['bold'] %}
-  {% set classes = classes|merge(['cta-block--' ~ font_weight]) %}
-{% endif %}
-{% if size in ['xcompact', 'compact', 'compact-responsive'] %}
-  {% set classes = classes|merge(['cta-block--' ~ size]) %}
-{% endif %}
+{% set classes = [
+  'cta-block',
+  color in ['alt', 'color-keystone', 'hollow-solid', 'hollow-dotted', 'light-blue', 'expand', 'expand-reversed']? 'cta-block--' ~ color,
+  color_dark in ['color-keystone', 'reversed', 'light-blue'] ? 'cta-block--on-dark-' ~ color_dark,
+  expand_to_fit ? 'cta-block--expand-to-fit',
+  font_weight in ['bold'] ? 'cta-block--' ~ font_weight,
+  size in ['xcompact', 'compact', 'compact-responsive'] ? 'cta-block--' ~ size,
+]|filter(class => class is not empty) %}
+
 {% apply spaceless %}
   <a
     class="{{ classes|join(' ') }}"

--- a/packages/cta/cta-block.twig
+++ b/packages/cta/cta-block.twig
@@ -1,17 +1,20 @@
 {# @TODO: Remove backwards-compatibility layer in 3.0.0 #}
+{% if not color_dark and color == 'reversed' %}
+  {% set reversed_legacy = true %}
+{% endif %}
 {% if not color_dark %}
-  {% if color == 'reversed' %}
-    {% set color_dark = 'reversed' %}
-  {% elseif color == 'color-keystone' %}
+  {% if color == 'color-keystone' %}
     {% set color_dark = 'color-keystone' %}
   {% elseif color == 'light-blue' %}
     {% set color_dark = 'light-blue' %}
+  {% else %}
+    {% set color_dark = 'reversed' %}
   {% endif %}
 {% endif %}
 
 {% set classes = [
   'cta-block',
-  color in ['alt', 'color-keystone', 'hollow-solid', 'hollow-dotted', 'light-blue', 'expand', 'expand-reversed']? 'cta-block--' ~ color,
+  reversed_legacy or color in ['alt', 'color-keystone', 'hollow-solid', 'hollow-dotted', 'light-blue', 'expand', 'expand-reversed'] ? 'cta-block--' ~ color,
   color_dark in ['color-keystone', 'reversed', 'light-blue'] ? 'cta-block--on-dark-' ~ color_dark,
   expand_to_fit ? 'cta-block--expand-to-fit',
   font_weight in ['bold'] ? 'cta-block--' ~ font_weight,

--- a/packages/cta/package.json
+++ b/packages/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/cta",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Provides a CTA button.",
   "publishConfig": {
     "access": "public",

--- a/packages/cta/src/scss/_cta-block.scss
+++ b/packages/cta/src/scss/_cta-block.scss
@@ -136,22 +136,7 @@
   }
 }
 
-@mixin cta-color($name, $background, $foreground, $background-active, $foreground-active, $outline) {
-  .cta-block--#{$name} {
-    background: $background;
-    color: $foreground;
-
-    &:hover, &:focus-visible {
-      background: $background-active;
-      color: $foreground-active;
-    }
-
-    &:focus-visible {
-      outline-color: $outline;
-    }
-  }
-}
-
+// Automatic contrasting.
 @mixin cta-color-light($name, $background, $foreground, $background-active, $foreground-active, $outline) {
   .cta-block--on-light-#{$name} {
     &, &:is([data-light] *) {
@@ -176,7 +161,6 @@
   }
 }
 
-// Automatic contrasting.
 @include cta-color-light('alt', var(--beaver-blue), var(--white), var(--nittany-navy), var(--white), var(--sky-blue));
 @include cta-color-light('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
 @include cta-color-light('expand', var(--cta-block-expand-background-color), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
@@ -191,6 +175,21 @@
 
 
 // Legacy coloration.
+@mixin cta-color($name, $background, $foreground, $background-active, $foreground-active, $outline) {
+  .cta-block--#{$name} {
+    background: $background;
+    color: $foreground;
+
+    &:hover, &:focus-visible {
+      background: $background-active;
+      color: $foreground-active;
+    }
+
+    &:focus-visible {
+      outline-color: $outline;
+    }
+  }
+}
 @include cta-color('alt', var(--beaver-blue), var(--white), var(--nittany-navy), var(--white), var(--sky-blue));
 @include cta-color('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
 @include cta-color('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
@@ -214,7 +213,8 @@
   }
 }
 
-.cta-block--hollow {
+.cta-block--hollow,
+.cta-block--on-light-hollow {
 
   &-dotted {
     &, &:hover, &:focus {
@@ -227,5 +227,12 @@
     &, &:hover, &:focus {
       border: _rem(.1) var(--pa-link) solid;
     }
+  }
+}
+
+.cta-block--on-light-hollow-solid,
+.cta-block--on-light-hollow-dotted {
+  &:is([data-dark] *) {
+    border: none;
   }
 }

--- a/packages/cta/src/scss/_cta-block.scss
+++ b/packages/cta/src/scss/_cta-block.scss
@@ -1,5 +1,6 @@
 /* Automatic contrasting color definitions */
 :root {
+  // @TODO: Bring the expand auto-contrasting into the fold operationally.
   --cta-block-expand-background-color-default: var(--light-mauve);
   --cta-block-expand-background-color-light: var(--white);
 
@@ -10,6 +11,14 @@
   @supports not (color: color-mix(in srgb, white, white)) {
     --box-shadow: _rem(.1) _rem(.1) 0 0 rgba($nittany-navy, .5);
   }
+
+  --cta-foreground-color: var(--text-color--light);
+  --cta-foreground-color-active: var(--text-color--light);
+
+  --cta-background-color: var(--pa-link);
+  --cta-background-color-active: var(--nittany-navy);
+
+  --cta-border: none;
 }
 
 .cta-block {
@@ -124,16 +133,6 @@
       margin: auto;
     }
   }
-
-  & {
-    --cta-foreground-color: var(--text-color--light);
-    --cta-foreground-color-active: var(--text-color--light);
-
-    --cta-background-color: var(--pa-link);
-    --cta-background-color-active: var(--nittany-navy);
-
-    --cta-border: none;
-  }
 }
 
 // Automatic contrasting.
@@ -174,7 +173,7 @@
 @include cta-color-dark('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
 
 
-// Legacy coloration.
+// Legacy forced color profiles.
 @mixin cta-color($name, $background, $foreground, $background-active, $foreground-active, $outline) {
   .cta-block--#{$name} {
     background: $background;

--- a/packages/cta/src/scss/_cta-block.scss
+++ b/packages/cta/src/scss/_cta-block.scss
@@ -11,18 +11,10 @@
   @supports not (color: color-mix(in srgb, white, white)) {
     --box-shadow: _rem(.1) _rem(.1) 0 0 rgba($nittany-navy, .5);
   }
-
-  --cta-foreground-color: var(--text-color--light);
-  --cta-foreground-color-active: var(--text-color--light);
-
-  --cta-background-color: var(--pa-link);
-  --cta-background-color-active: var(--nittany-navy);
-
-  --cta-border: none;
 }
 
 .cta-block {
-  border: var(--cta-border);
+  border: none;
   display:inline-block;
   padding: _rem(1.5) _rem(3);
   font-family: var(--font-family--default);
@@ -31,7 +23,9 @@
   font-weight: 600;
   text-decoration:none;
   border-radius: var(--button-border-radius--default);
-  transition: background-color .2s ease-in-out, color .2s ease-in-out;
+  transition: background-color var(--transition-duration--default) ease-in-out,
+              border-color var(--transition-duration--default) ease-in-out,
+              color var(--transition-duration--default) ease-in-out;
   text-align:center;
   color: var(--cta-foreground-color);
   background-color: var(--cta-background-color);
@@ -39,29 +33,38 @@
   outline-offset: _rem(-.5);
   position: relative;
 
-  @include bp(m) {
-    padding: _rem(1.7) _rem(3.125);
+  &, &:is([data-light] *) {
+    --cta-foreground-color: var(--text-color--light);
+    --cta-foreground-color-active: var(--text-color--light);
+
+    --cta-background-color: var(--pa-link);
+    --cta-background-color-active: var(--nittany-navy);
+    --cta-outline-color: var(--sky-blue);
   }
 
-  &:focus {
-    outline: none;
+  &:is([data-dark] *) {
+    --cta-foreground-color: var(--beaver-blue);
+    --cta-foreground-color-active: var(--beaver-blue);
+
+    --cta-background-color: var(--white);
+    --cta-background-color-active: var(--keystone-light);
+    --cta-outline-color: var(--nittany-navy);
+  }
+
+  @include bp(m) {
+    padding: _rem(1.7) _rem(3.125);
   }
 
   &:hover, &:focus-visible {
     text-decoration: none;
     background-color: var(--cta-background-color-active);
-    border-bottom: none;
     color: var(--cta-foreground-color-active);
     cursor: pointer;
   }
 
   &:focus-visible {
-    outline: _rem(.2) solid var(--sky-blue);
+    outline: _rem(.2) solid var(--cta-outline-color);
     outline-offset: _rem(-.5);
-  }
-
-  &:hover {
-    outline: none;
   }
 
   &--compact {
@@ -136,14 +139,18 @@
 }
 
 // Automatic contrasting.
+@mixin cta-colors($background, $foreground, $background-active, $foreground-active, $outline) {
+  --cta-background-color: #{$background};
+  --cta-background-color-active: #{$background-active};
+  --cta-foreground-color: #{$foreground};
+  --cta-foreground-color-active: #{$foreground-active};
+  --cta-outline-color: #{$outline};
+}
+
 @mixin cta-color-light($name, $background, $foreground, $background-active, $foreground-active, $outline) {
-  .cta-block--on-light-#{$name} {
+  .cta-block--#{$name} {
     &, &:is([data-light] *) {
-      --cta-background-color: #{$background};
-      --cta-background-color-active: #{$background-active};
-      --cta-foreground-color: #{$foreground};
-      --cta-foreground-color-active: #{$foreground-active};
-      --cta-outline-color: #{$outline};
+      @include cta-colors($background, $foreground, $background-active, $foreground-active, $outline);
     }
   }
 }
@@ -151,52 +158,22 @@
 @mixin cta-color-dark($name, $background, $foreground, $background-active, $foreground-active, $outline) {
   .cta-block--on-dark-#{$name} {
     &:is([data-dark] *) {
-      --cta-background-color: #{$background};
-      --cta-background-color-active: #{$background-active};
-      --cta-foreground-color: #{$foreground};
-      --cta-foreground-color-active: #{$foreground-active};
-      --cta-outline-color: #{$outline};
+      @include cta-colors($background, $foreground, $background-active, $foreground-active, $outline);
     }
   }
 }
 
 @include cta-color-light('alt', var(--beaver-blue), var(--white), var(--nittany-navy), var(--white), var(--sky-blue));
 @include cta-color-light('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
-@include cta-color-light('expand', var(--cta-block-expand-background-color), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
 @include cta-color-light('hollow-solid', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
 @include cta-color-light('hollow-dotted', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
 @include cta-color-light('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
+@include cta-color-light('expand', var(--cta-block-expand-background-color), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+@include cta-color-light('expand-reversed', var(--text-color--light), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
 
 @include cta-color-dark('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
 @include cta-color-dark('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
-@include cta-color-dark('expand', var(--text-color--light), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
 @include cta-color-dark('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
-
-
-// Legacy forced color profiles.
-@mixin cta-color($name, $background, $foreground, $background-active, $foreground-active, $outline) {
-  .cta-block--#{$name} {
-    background: $background;
-    color: $foreground;
-
-    &:hover, &:focus-visible {
-      background: $background-active;
-      color: $foreground-active;
-    }
-
-    &:focus-visible {
-      outline-color: $outline;
-    }
-  }
-}
-@include cta-color('alt', var(--beaver-blue), var(--white), var(--nittany-navy), var(--white), var(--sky-blue));
-@include cta-color('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
-@include cta-color('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
-@include cta-color('expand', var(--cta-block-expand-background-color), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
-@include cta-color('expand-reversed', var(--text-color--light), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
-@include cta-color('hollow-solid', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
-@include cta-color('hollow-dotted', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
-@include cta-color('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
 
 .cta-block--expand {
   transition: color .3s linear, background-color .3s linear, box-shadow .3s linear;
@@ -212,26 +189,26 @@
   }
 }
 
-.cta-block--hollow,
-.cta-block--on-light-hollow {
+.cta-block--hollow-dotted,
+.cta-block--hollow-solid {
+  border-width: _rem(.1);
 
-  &-dotted {
-    &, &:hover, &:focus {
-      border: _rem(.1) var(--pa-link) dotted;
-
+  &, &:is([data-light] *) {
+    &:hover, &:focus {
+      border-color: var(--pa-link);
     }
   }
 
-  &-solid {
-    &, &:hover, &:focus {
-      border: _rem(.1) var(--pa-link) solid;
-    }
-  }
-}
-
-.cta-block--on-light-hollow-solid,
-.cta-block--on-light-hollow-dotted {
   &:is([data-dark] *) {
-    border: none;
+    border-color: transparent;
   }
 }
+
+.cta-block--hollow-solid {
+  border-style: solid;
+}
+
+.cta-block--hollow-dotted {
+  border-style: dotted;
+}
+

--- a/packages/cta/src/scss/_cta-block.scss
+++ b/packages/cta/src/scss/_cta-block.scss
@@ -67,6 +67,42 @@
     outline-offset: _rem(-.5);
   }
 
+  @mixin cta-colors($background, $foreground, $background-active, $foreground-active, $outline) {
+    --cta-background-color: #{$background};
+    --cta-background-color-active: #{$background-active};
+    --cta-foreground-color: #{$foreground};
+    --cta-foreground-color-active: #{$foreground-active};
+    --cta-outline-color: #{$outline};
+  }
+
+  @mixin cta-color-light($name, $background, $foreground, $background-active, $foreground-active, $outline) {
+    &--#{$name} {
+      &, &:is([data-light] *) {
+        @include cta-colors($background, $foreground, $background-active, $foreground-active, $outline);
+      }
+    }
+  }
+
+  @mixin cta-color-dark($name, $background, $foreground, $background-active, $foreground-active, $outline) {
+    &--on-dark-#{$name} {
+      &:is([data-dark] *) {
+        @include cta-colors($background, $foreground, $background-active, $foreground-active, $outline);
+      }
+    }
+  }
+
+  @include cta-color-light('alt', var(--beaver-blue), var(--white), var(--nittany-navy), var(--white), var(--sky-blue));
+  @include cta-color-light('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
+  @include cta-color-light('hollow-solid', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+  @include cta-color-light('hollow-dotted', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+  @include cta-color-light('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
+  @include cta-color-light('expand', var(--cta-block-expand-background-color), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+  @include cta-color-light('expand-reversed', var(--text-color--light), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+
+  @include cta-color-dark('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
+  @include cta-color-dark('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
+  @include cta-color-dark('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
+
   &--compact {
     font-size: var(--font-size--small);
     padding: _rem(1.3) _rem(2.2);
@@ -137,43 +173,6 @@
     }
   }
 }
-
-// Automatic contrasting.
-@mixin cta-colors($background, $foreground, $background-active, $foreground-active, $outline) {
-  --cta-background-color: #{$background};
-  --cta-background-color-active: #{$background-active};
-  --cta-foreground-color: #{$foreground};
-  --cta-foreground-color-active: #{$foreground-active};
-  --cta-outline-color: #{$outline};
-}
-
-@mixin cta-color-light($name, $background, $foreground, $background-active, $foreground-active, $outline) {
-  .cta-block--#{$name} {
-    &, &:is([data-light] *) {
-      @include cta-colors($background, $foreground, $background-active, $foreground-active, $outline);
-    }
-  }
-}
-
-@mixin cta-color-dark($name, $background, $foreground, $background-active, $foreground-active, $outline) {
-  .cta-block--on-dark-#{$name} {
-    &:is([data-dark] *) {
-      @include cta-colors($background, $foreground, $background-active, $foreground-active, $outline);
-    }
-  }
-}
-
-@include cta-color-light('alt', var(--beaver-blue), var(--white), var(--nittany-navy), var(--white), var(--sky-blue));
-@include cta-color-light('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
-@include cta-color-light('hollow-solid', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
-@include cta-color-light('hollow-dotted', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
-@include cta-color-light('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
-@include cta-color-light('expand', var(--cta-block-expand-background-color), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
-@include cta-color-light('expand-reversed', var(--text-color--light), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
-
-@include cta-color-dark('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
-@include cta-color-dark('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
-@include cta-color-dark('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
 
 .cta-block--expand {
   transition: color .3s linear, background-color .3s linear, box-shadow .3s linear;

--- a/packages/cta/src/scss/_cta-block.scss
+++ b/packages/cta/src/scss/_cta-block.scss
@@ -98,6 +98,8 @@
   @include cta-color-light('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
   @include cta-color-light('expand', var(--cta-block-expand-background-color), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
   @include cta-color-light('expand-reversed', var(--text-color--light), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+  // @TODO: Remove reversed-on-light b/c layer in 3.0.0.
+  @include cta-color-light('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
 
   @include cta-color-dark('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
   @include cta-color-dark('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy));

--- a/packages/cta/src/scss/_cta-block.scss
+++ b/packages/cta/src/scss/_cta-block.scss
@@ -22,8 +22,6 @@
 }
 
 .cta-block {
-  background-color: var(--cta-background-color);
-  color: var(--cta-foreground-color);
   border: var(--cta-border);
   display:inline-block;
   padding: _rem(1.5) _rem(3);
@@ -35,6 +33,8 @@
   border-radius: var(--button-border-radius--default);
   transition: background-color .2s ease-in-out, color .2s ease-in-out;
   text-align:center;
+  color: var(--cta-foreground-color);
+  background-color: var(--cta-background-color);
   margin-bottom: 0;
   outline-offset: _rem(-.5);
   position: relative;

--- a/packages/cta/src/scss/_cta-block.scss
+++ b/packages/cta/src/scss/_cta-block.scss
@@ -13,7 +13,9 @@
 }
 
 .cta-block {
-  border: none;
+  background-color: var(--cta-background-color);
+  color: var(--cta-foreground-color);
+  border: var(--cta-border);
   display:inline-block;
   padding: _rem(1.5) _rem(3);
   font-family: var(--font-family--default);
@@ -24,8 +26,6 @@
   border-radius: var(--button-border-radius--default);
   transition: background-color .2s ease-in-out, color .2s ease-in-out;
   text-align:center;
-  color: var(--text-color--light);
-  background: var(--pa-link);
   margin-bottom: 0;
   outline-offset: _rem(-.5);
   position: relative;
@@ -40,9 +40,9 @@
 
   &:hover, &:focus-visible {
     text-decoration: none;
-    background-color: var(--nittany-navy);
+    background-color: var(--cta-background-color-active);
     border-bottom: none;
-    color: var(--text-color--light);
+    color: var(--cta-foreground-color-active);
     cursor: pointer;
   }
 
@@ -112,7 +112,6 @@
     display: inline-flex;
     transition: color .2s ease-in-out;
     font-size: _rem(1.3);
-    color: var(--light-mauve);
     vertical-align: middle;
     &--before {
       margin-right: _rem(0.8);
@@ -125,9 +124,19 @@
       margin: auto;
     }
   }
+
+  & {
+    --cta-foreground-color: var(--text-color--light);
+    --cta-foreground-color-active: var(--text-color--light);
+
+    --cta-background-color: var(--pa-link);
+    --cta-background-color-active: var(--nittany-navy);
+
+    --cta-border: none;
+  }
 }
 
-@mixin cta-color($name, $background, $foreground, $background-active, $foreground-active, $outline, $icon, $icon-active) {
+@mixin cta-color($name, $background, $foreground, $background-active, $foreground-active, $outline) {
   .cta-block--#{$name} {
     background: $background;
     color: $foreground;
@@ -135,30 +144,61 @@
     &:hover, &:focus-visible {
       background: $background-active;
       color: $foreground-active;
-
-      .cta-block__icon {
-        color: $icon-active;
-      }
     }
 
     &:focus-visible {
       outline-color: $outline;
     }
+  }
+}
 
-    .cta-block__icon {
-      color: $icon;
+@mixin cta-color-light($name, $background, $foreground, $background-active, $foreground-active, $outline) {
+  .cta-block--on-light-#{$name} {
+    &, &:is([data-light] *) {
+      --cta-background-color: #{$background};
+      --cta-background-color-active: #{$background-active};
+      --cta-foreground-color: #{$foreground};
+      --cta-foreground-color-active: #{$foreground-active};
+      --cta-outline-color: #{$outline};
     }
   }
 }
 
-@include cta-color('alt', var(--beaver-blue), var(--white), var(--nittany-navy), var(--white), var(--sky-blue), var(--light-mauve), var(--light-mauve));
-@include cta-color('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy), var(--pa-link), var(--pa-link));
-@include cta-color('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy), var(--black), var(--black));
-@include cta-color('expand', var(--cta-block-expand-background-color), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy), var(--beaver-blue), var(--nittany-navy));
-@include cta-color('expand-reversed', var(--text-color--light), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy), var(--beaver-blue), var(--nittany-navy));
-@include cta-color('hollow-solid', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy), var(--beaver-blue), var(--nittany-navy));
-@include cta-color('hollow-dotted', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy), var(--beaver-blue), var(--nittany-navy));
-@include cta-color('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy), var(--pa-link), var(--pa-link));
+@mixin cta-color-dark($name, $background, $foreground, $background-active, $foreground-active, $outline) {
+  .cta-block--on-dark-#{$name} {
+    &:is([data-dark] *) {
+      --cta-background-color: #{$background};
+      --cta-background-color-active: #{$background-active};
+      --cta-foreground-color: #{$foreground};
+      --cta-foreground-color-active: #{$foreground-active};
+      --cta-outline-color: #{$outline};
+    }
+  }
+}
+
+// Automatic contrasting.
+@include cta-color-light('alt', var(--beaver-blue), var(--white), var(--nittany-navy), var(--white), var(--sky-blue));
+@include cta-color-light('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
+@include cta-color-light('expand', var(--cta-block-expand-background-color), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+@include cta-color-light('hollow-solid', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+@include cta-color-light('hollow-dotted', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+@include cta-color-light('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
+
+@include cta-color-dark('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
+@include cta-color-dark('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
+@include cta-color-dark('expand', var(--text-color--light), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+@include cta-color-dark('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
+
+
+// Legacy coloration.
+@include cta-color('alt', var(--beaver-blue), var(--white), var(--nittany-navy), var(--white), var(--sky-blue));
+@include cta-color('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
+@include cta-color('color-keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));
+@include cta-color('expand', var(--cta-block-expand-background-color), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+@include cta-color('expand-reversed', var(--text-color--light), var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+@include cta-color('hollow-solid', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+@include cta-color('hollow-dotted', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+@include cta-color('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
 
 .cta-block--expand {
   transition: color .3s linear, background-color .3s linear, box-shadow .3s linear;

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/atoms/cta/_cta.md
+++ b/packages/patternlab/source/patterns/atoms/cta/_cta.md
@@ -3,17 +3,15 @@ order: 3
 title: CTA
 ---
 # Variables
-| Variable      | Type    | Required | Description                                                                                                                |
-|---------------|---------|----------|----------------------------------------------------------------------------------------------------------------------------|
-| size          | string  | false    | The size variation of the cta component                                                                                    |
-| expand_to_fit | boolean | false    | If true, the cta component will expand the width of parent container                                                       |
-| color         | string  | false    | The forced color variation of the cta component (**for enhanced accessibility, use the light/dark feature when possible**) |
-| color_light   | string  | false    | The preferred color if the cta exists on a light background                                                                |
-| color_dark    | string  | false    | The preferred color if the cta exists on a dark background                                                                 |
-| font_weight   | string  | false    | The font weighting of the cta component                                                                                    |
-| label         | string  | false    | The label of the cta component                                                                                             |
-| url           | string  | false    | The url of the cta link                                                                                                    |
-
+| Variable      | Type    | Required | Description                                                                         |
+|---------------|---------|----------|-------------------------------------------------------------------------------------|
+| label         | string  | true     | The label of the cta component                                                      |
+| url           | string  | true     | The url of the cta link                                                             |
+| color         | string  | false    | The preferred color variation of the cta component                                  |
+| color_dark    | string  | false    | The preferred color if the cta exists on a dark background (defaults to 'reversed') |
+| font_weight   | string  | false    | The font weighting of the cta component                                             |
+| size          | string  | false    | The size variation of the cta component                                             |
+| expand_to_fit | boolean | false    | If true, the cta component will expand the width of parent container                |
 
 ## Size modifiers
 | Size               | Description                                                                       |
@@ -28,15 +26,22 @@ title: CTA
 | bold     | If specified, the cta component will be bolded |
 
 ## Color modifiers
-| Modifier       | Description                                                                      |
-|----------------|----------------------------------------------------------------------------------|
-| alt            | If specified, the cta component will have the color modifier of 'alt'            |
-| expand         | If specified, the cta component will have the color modifier of 'expand'         |
-| hollow-dotted  | If specified, the cta component will have the color modifier of 'hollow-dotted'  |
-| hollow-solid   | If specified, the cta component will have the color modifier of 'hollow-solid'   |
-| color-keystone | If specified, the cta component will have the color modifier of 'color-keystone' |
-| light-blue     | If specified, the cta component will have the color modifier of 'light-blue'     |
-| reversed       | If specified, the cta component will have the color modifier of 'reversed'       |
+| Modifier         | Description                                                                       |
+|------------------|-----------------------------------------------------------------------------------|
+| alt              | If specified, the cta component will have the color modifier of 'alt'             |
+| hollow-dotted    | If specified, the cta component will have the color modifier of 'hollow-dotted'   |
+| hollow-solid     | If specified, the cta component will have the color modifier of 'hollow-solid'    |
+| color-keystone   | If specified, the cta component will have the color modifier of 'color-keystone'  |
+| light-blue       | If specified, the cta component will have the color modifier of 'light-blue'      |
+| expand           | If specified, the cta component will have the color modifier of 'expand'          |
+| expand-reversed  | If specified, the cta component will have the color modifier of 'expand-reversed' |
+
+## Dark color modifiers
+| Modifier        | Description                                                                       |
+|-----------------|-----------------------------------------------------------------------------------|
+| reversed        | If specified, the cta component will have the color modifier of 'reversed'        |
+| color-keystone  | If specified, the cta component will have the color modifier of 'color-keystone'  |
+| light-blue      | If specified, the cta component will have the color modifier of 'light-blue'      |
 
 ## Icon modifiers
 | Modifier       | Description                                                            |

--- a/packages/patternlab/source/patterns/atoms/cta/_cta.md
+++ b/packages/patternlab/source/patterns/atoms/cta/_cta.md
@@ -8,7 +8,7 @@ title: CTA
 | label         | string  | true     | The label of the cta component                                                      |
 | url           | string  | true     | The url of the cta link                                                             |
 | color         | string  | false    | The preferred color variation of the cta component                                  |
-| color_on_dark    | string  | false    | The preferred color if the cta exists on a dark background (defaults to 'reversed') |
+| color_on_dark | string  | false    | The preferred color if the cta exists on a dark background (defaults to 'reversed') |
 | font_weight   | string  | false    | The font weighting of the cta component                                             |
 | size          | string  | false    | The size variation of the cta component                                             |
 | expand_to_fit | boolean | false    | If true, the cta component will expand the width of parent container                |

--- a/packages/patternlab/source/patterns/atoms/cta/_cta.md
+++ b/packages/patternlab/source/patterns/atoms/cta/_cta.md
@@ -8,7 +8,7 @@ title: CTA
 | label         | string  | true     | The label of the cta component                                                      |
 | url           | string  | true     | The url of the cta link                                                             |
 | color         | string  | false    | The preferred color variation of the cta component                                  |
-| color_dark    | string  | false    | The preferred color if the cta exists on a dark background (defaults to 'reversed') |
+| color_on_dark    | string  | false    | The preferred color if the cta exists on a dark background (defaults to 'reversed') |
 | font_weight   | string  | false    | The font weighting of the cta component                                             |
 | size          | string  | false    | The size variation of the cta component                                             |
 | expand_to_fit | boolean | false    | If true, the cta component will expand the width of parent container                |

--- a/packages/patternlab/source/patterns/atoms/cta/_cta.md
+++ b/packages/patternlab/source/patterns/atoms/cta/_cta.md
@@ -3,14 +3,16 @@ order: 3
 title: CTA
 ---
 # Variables
-| Variable      | Type    | Required | Description                                                           |
-|---------------|---------|----------|-----------------------------------------------------------------------|
-| size          | string  | false    | The size variation of the cta component                               |
-| expand_to_fit | boolean | false    | If true, the cta component will expand the width of parent container  |
-| color         | string  | false    | The color variation of the cta component                              |
-| font_weight   | string  | false    | The font weighting of the cta component                               |
-| label         | string  | false    | The label of the cta component                                        |
-| url           | string  | false    | The url of the cta link                                               |
+| Variable      | Type    | Required | Description                                                                                                                |
+|---------------|---------|----------|----------------------------------------------------------------------------------------------------------------------------|
+| size          | string  | false    | The size variation of the cta component                                                                                    |
+| expand_to_fit | boolean | false    | If true, the cta component will expand the width of parent container                                                       |
+| color         | string  | false    | The forced color variation of the cta component (**for enhanced accessibility, use the light/dark feature when possible**) |
+| color_light   | string  | false    | The preferred color if the cta exists on a light background                                                                |
+| color_dark    | string  | false    | The preferred color if the cta exists on a dark background                                                                 |
+| font_weight   | string  | false    | The font weighting of the cta component                                                                                    |
+| label         | string  | false    | The label of the cta component                                                                                             |
+| url           | string  | false    | The url of the cta link                                                                                                    |
 
 
 ## Size modifiers

--- a/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
@@ -81,7 +81,7 @@
     color_dark: 'color-keystone'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Light Blue | Light blue',
+    label: 'Light Blue | Light Blue',
     url: '#',
     color: 'light-blue',
     color_dark: 'light-blue'

--- a/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
@@ -3,7 +3,6 @@
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Default | Reversed',
     url: '#',
-    color_dark: 'reversed'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Default | Keystone',
@@ -11,62 +10,80 @@
     color_dark: 'color-keystone'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Default | Light blue',
+    label: 'Default | Light Blue',
     url: '#',
     color_dark: 'light-blue'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Alt | Reversed',
     url: '#',
-    color_light: 'alt',
+    color: 'alt',
     color_dark: 'reversed'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Alt | Keystone',
     url: '#',
-    color_light: 'alt',
+    color: 'alt',
     color_dark: 'color-keystone'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Alt | Light blue',
+    label: 'Alt | Light Blue',
     url: '#',
-    color_light: 'alt',
+    color: 'alt',
     color_dark: 'light-blue'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Hollow Solid | Reversed',
     url: '#',
-    color_light: 'hollow-solid',
+    color: 'hollow-solid',
     color_dark: 'reversed'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Hollow Solid | Keystone',
     url: '#',
-    color_light: 'hollow-solid',
+    color: 'hollow-solid',
     color_dark: 'color-keystone'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Hollow Solid | Light blue',
+    label: 'Hollow Solid | Light Blue',
     url: '#',
-    color_light: 'hollow-solid',
+    color: 'hollow-solid',
     color_dark: 'light-blue'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Hollow Dotted | Reversed',
     url: '#',
-    color_light: 'hollow-dotted',
+    color: 'hollow-dotted',
     color_dark: 'reversed'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Hollow Dotted | Keystone',
     url: '#',
-    color_light: 'hollow-dotted',
+    color: 'hollow-dotted',
     color_dark: 'color-keystone'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Hollow Dotted | Light blue',
+    label: 'Hollow Dotted | Light Blue',
     url: '#',
-    color_light: 'hollow-dotted',
+    color: 'hollow-dotted',
+    color_dark: 'light-blue'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Light Blue | Reversed',
+    url: '#',
+    color: 'light-blue',
+    color_dark: 'reversed'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Light Blue | Keystone',
+    url: '#',
+    color: 'light-blue',
+    color_dark: 'color-keystone'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Light Blue | Light blue',
+    url: '#',
+    color: 'light-blue',
     color_dark: 'light-blue'
   } only %}
 </div>

--- a/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
@@ -33,6 +33,42 @@
     color_light: 'alt',
     color_dark: 'light-blue'
   } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Hollow Solid | Reversed',
+    url: '#',
+    color_light: 'hollow-solid',
+    color_dark: 'reversed'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Hollow Solid | Keystone',
+    url: '#',
+    color_light: 'hollow-solid',
+    color_dark: 'color-keystone'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Hollow Solid | Light blue',
+    url: '#',
+    color_light: 'hollow-solid',
+    color_dark: 'light-blue'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Hollow Dotted | Reversed',
+    url: '#',
+    color_light: 'hollow-dotted',
+    color_dark: 'reversed'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Hollow Dotted | Keystone',
+    url: '#',
+    color_light: 'hollow-dotted',
+    color_dark: 'color-keystone'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Hollow Dotted | Light blue',
+    url: '#',
+    color_light: 'hollow-dotted',
+    color_dark: 'light-blue'
+  } only %}
 </div>
 <script>
   (()=>{

--- a/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
@@ -7,84 +7,84 @@
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Default | Keystone',
     url: '#',
-    color_dark: 'color-keystone'
+    color_on_dark: 'color-keystone'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Default | Light Blue',
     url: '#',
-    color_dark: 'light-blue'
+    color_on_dark: 'light-blue'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Alt | Reversed',
     url: '#',
     color: 'alt',
-    color_dark: 'reversed'
+    color_on_dark: 'reversed'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Alt | Keystone',
     url: '#',
     color: 'alt',
-    color_dark: 'color-keystone'
+    color_on_dark: 'color-keystone'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Alt | Light Blue',
     url: '#',
     color: 'alt',
-    color_dark: 'light-blue'
+    color_on_dark: 'light-blue'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Hollow Solid | Reversed',
     url: '#',
     color: 'hollow-solid',
-    color_dark: 'reversed'
+    color_on_dark: 'reversed'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Hollow Solid | Keystone',
     url: '#',
     color: 'hollow-solid',
-    color_dark: 'color-keystone'
+    color_on_dark: 'color-keystone'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Hollow Solid | Light Blue',
     url: '#',
     color: 'hollow-solid',
-    color_dark: 'light-blue'
+    color_on_dark: 'light-blue'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Hollow Dotted | Reversed',
     url: '#',
     color: 'hollow-dotted',
-    color_dark: 'reversed'
+    color_on_dark: 'reversed'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Hollow Dotted | Keystone',
     url: '#',
     color: 'hollow-dotted',
-    color_dark: 'color-keystone'
+    color_on_dark: 'color-keystone'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Hollow Dotted | Light Blue',
     url: '#',
     color: 'hollow-dotted',
-    color_dark: 'light-blue'
+    color_on_dark: 'light-blue'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Light Blue | Reversed',
     url: '#',
     color: 'light-blue',
-    color_dark: 'reversed'
+    color_on_dark: 'reversed'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Light Blue | Keystone',
     url: '#',
     color: 'light-blue',
-    color_dark: 'color-keystone'
+    color_on_dark: 'color-keystone'
   } only %}
   {% include '@psu-ooe/cta/cta-block.twig' with {
     label: 'Light Blue | Light Blue',
     url: '#',
     color: 'light-blue',
-    color_dark: 'light-blue'
+    color_on_dark: 'light-blue'
   } only %}
 </div>
 <script>

--- a/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
@@ -1,0 +1,64 @@
+<input type="checkbox" name="cta_dark_mode" id="cta_dark_mode"><label for="cta_dark_mode">Toggle dark mode</label>
+<div id="cta_auto_contrast">
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Default | Reversed',
+    url: '#',
+    color_dark: 'reversed'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Default | Keystone',
+    url: '#',
+    color_dark: 'color-keystone'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Default | Light blue',
+    url: '#',
+    color_dark: 'light-blue'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Alt | Reversed',
+    url: '#',
+    color_light: 'alt',
+    color_dark: 'reversed'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Alt | Keystone',
+    url: '#',
+    color_light: 'alt',
+    color_dark: 'color-keystone'
+  } only %}
+  {% include '@psu-ooe/cta/cta-block.twig' with {
+    label: 'Alt | Light blue',
+    url: '#',
+    color_light: 'alt',
+    color_dark: 'light-blue'
+  } only %}
+</div>
+<script>
+  (()=>{
+    const wrapper = document.getElementById('cta_auto_contrast');
+    document.getElementById('cta_dark_mode').addEventListener('change', () => {
+      if (wrapper.hasAttribute('data-dark')) {
+        wrapper.removeAttribute('data-dark');
+        wrapper.setAttribute('data-light', '');
+      }
+      else {
+        wrapper.removeAttribute('data-light');
+        wrapper.setAttribute('data-dark', '');
+      }
+    });
+  })();
+</script>
+<style>
+  #cta_auto_contrast {
+    background-color: var(--white);
+    padding: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  #cta_auto_contrast[data-dark] {
+    background-color: var(--beaver-blue);
+  }
+</style>

--- a/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
@@ -1,91 +1,30 @@
 <input type="checkbox" name="cta_dark_mode" id="cta_dark_mode"><label for="cta_dark_mode">Toggle dark mode</label>
 <div id="cta_auto_contrast">
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Default | Reversed',
-    url: '#',
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Default | Keystone',
-    url: '#',
-    color_on_dark: 'color-keystone'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Default | Light Blue',
-    url: '#',
-    color_on_dark: 'light-blue'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Alt | Reversed',
-    url: '#',
-    color: 'alt',
-    color_on_dark: 'reversed'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Alt | Keystone',
-    url: '#',
-    color: 'alt',
-    color_on_dark: 'color-keystone'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Alt | Light Blue',
-    url: '#',
-    color: 'alt',
-    color_on_dark: 'light-blue'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Hollow Solid | Reversed',
-    url: '#',
-    color: 'hollow-solid',
-    color_on_dark: 'reversed'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Hollow Solid | Keystone',
-    url: '#',
-    color: 'hollow-solid',
-    color_on_dark: 'color-keystone'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Hollow Solid | Light Blue',
-    url: '#',
-    color: 'hollow-solid',
-    color_on_dark: 'light-blue'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Hollow Dotted | Reversed',
-    url: '#',
-    color: 'hollow-dotted',
-    color_on_dark: 'reversed'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Hollow Dotted | Keystone',
-    url: '#',
-    color: 'hollow-dotted',
-    color_on_dark: 'color-keystone'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Hollow Dotted | Light Blue',
-    url: '#',
-    color: 'hollow-dotted',
-    color_on_dark: 'light-blue'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Light Blue | Reversed',
-    url: '#',
-    color: 'light-blue',
-    color_on_dark: 'reversed'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Light Blue | Keystone',
-    url: '#',
-    color: 'light-blue',
-    color_on_dark: 'color-keystone'
-  } only %}
-  {% include '@psu-ooe/cta/cta-block.twig' with {
-    label: 'Light Blue | Light Blue',
-    url: '#',
-    color: 'light-blue',
-    color_on_dark: 'light-blue'
-  } only %}
+  {% set buttons = {
+    'Default | Reversed': ['', 'reversed'],
+    'Default | Keystone': ['', 'color-keystone'],
+    'Default | Light Blue': ['', 'light-blue'],
+    'Alt | Reversed': ['alt', 'reversed'],
+    'Alt | Keystone': ['alt', 'color-keystone'],
+    'Alt | Light Blue': ['alt', 'light-blue'],
+    'Hollow Solid | Reversed': ['hollow-solid', 'reversed'],
+    'Hollow Solid | Keystone': ['hollow-solid', 'color-keystone'],
+    'Hollow Solid | Light Blue': ['hollow-solid', 'light-blue'],
+    'Hollow Dotted | Reversed': ['hollow-dotted', 'reversed'],
+    'Hollow Dotted | Keystone': ['hollow-dotted', 'color-keystone'],
+    'Hollow Dotted | Light Blue': ['hollow-dotted', 'light-blue'],
+    'Light Blue | Reversed': ['light-blue', 'reversed'],
+    'Light Blue | Keystone': ['light-blue', 'color-keystone'],
+    'Light Blue | Light Blue': ['light-blue', 'light-blue']
+  } %}
+  {% for label, colors in buttons %}
+    {% include '@psu-ooe/cta/cta-block.twig' with {
+      label: label,
+      url: '#',
+      color: colors[0],
+      color_on_dark: colors[1],
+    } only %}
+  {% endfor %}
 </div>
 <script>
   (()=>{

--- a/packages/patternlab/source/patterns/atoms/cta/cta~backwards-compatibility.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~backwards-compatibility.twig
@@ -1,0 +1,19 @@
+<p>These patterns ensure that callers will continue to be supported even without light/dark metadata.</p>
+{% include '@psu-ooe/cta/cta-block.twig' with {
+  label: 'Backwards Compatibility',
+  url: '#',
+  color: 'color-keystone',
+} only %}
+
+{% include '@psu-ooe/cta/cta-block.twig' with {
+  label: 'Backwards Compatibility',
+  url: '#',
+  color: 'light-blue',
+} only %}
+
+{% include '@psu-ooe/cta/cta-block.twig' with {
+  label: 'Backwards Compatibility',
+  url: '#',
+  color: 'reversed',
+} only %}
+


### PR DESCRIPTION
# Description:
Presently, we only have forced color profiles that are generally available for call to action buttons. This means that the server more or less requires foreknowledge of the context the components will be placed in.

By using preferred colors, we can make this much more robust and easy to work with moving forward.

Changes include:
- A new optional input to the CTA block: `color_on_dark` which accepts one of `reversed`, `color-keystone`, or `light-blue`.  If not specified, `color_dark` will default to `reversed`.
- Restrict the acceptable `color` inputs to `alt`, `color-keystone`, `hollow-solid`, `hollow-dotted`, `light-blue`, `expand`, and `expand-reversed`.
- A backwards compatibility layer to prevent disruption on roll-out: If `color_on_dark` is not set and `color` is set to `color-keystone`, then `color-keystone` is copied into `color_dark` (to preserve the current behavior).  Likewise for `light-blue`.  The only other thing that the layer needs to do is to allow the `reversed` color to be rendered on contextless backgrounds.  One example of reversed-on-contextless is the prospect site header.

After 3.0.0, the b/c layer can be removed and leave only
```
{% if not color_on_dark %}
  {% set color_on_dark = 'reversed' %}
{% endif %}
```
behind.

Usage:

```
{% include '@psu-ooe/cta/cta-block.twig' with {
  label: 'Click me',
  url: '#',
  color: 'hollow-dotted',
  color_on_dark: 'light-blue',
} only %}
```

## Metadata
### Workfront Task Link
  https://pennstateoutreach.my.workfront.com/task/6633e0050038d2b1180576c48cd706f5/overview

### Adobe XD Link
  N/A

### Review environment Link
  https://developers.outreach.psu.edu/cta-preferred-colors/?p=viewall-atoms-cta -- I've added an "auto contrasting" example that should hit all supported permutations.