### PR TITLE
Add light/dark context to background containers

### DIFF
--- a/packages/background-container/background-container.twig
+++ b/packages/background-container/background-container.twig
@@ -1,4 +1,7 @@
-{% set classes = classes|default([]) %}
+{% set color_profiles = {
+  'light-grey': 'light',
+  'beaver-blue': 'dark',
+} %}
 
 {% set background_image_options = {
   'hub-geometric:topleft': ['hub-geometric'],
@@ -12,24 +15,19 @@
   'shield:program-page-banner-top': ['community-shield'],
   'shield:program-page-at-a-glance': ['community-shield'],
 } %}
-{% set classes = (classes|default([]))|merge(['bg', 'bg--' ~ color]) %}
-{% if padding %}
-  {% set classes = classes|merge(['bg--padding-' ~ padding]) %}
-{% endif %}
-{% if width %}
-  {% set classes = classes|merge(['bg--' ~ width]) %}
-{% endif %}
-{% if background_image and background_image in background_image_options|keys %}
-  {% set sprites = background_image_options[background_image] %}
-  {% set classes = classes|merge([
-    'bg--' ~ background_image|replace({':':'-'})
-  ]) %}
-{% endif %}
+{% set classes = classes|default([])|merge([
+  'bg',
+  color in color_profiles|keys ? 'bg--' ~ color,
+  background_image in background_image_options|keys ? 'bg--' ~ background_image|replace({':':'-'}),
+  padding in ['small', 'large'] ? 'bg--padding-' ~ padding,
+  width in ['narrow'] ? 'bg--' ~ width,
+])|filter(class => class is not empty) %}
+
 {# @TODO: Implement more graceful attribute management... #}
-<div class="{{ classes|join(' ') }}" {{ attributes }}>
-  {% if sprites %}
+<div class="{{ classes|join(' ') }}" {% if color in color_profiles|keys %}data-{{ color_profiles[color] }}{% endif %} {{ attributes }}>
+  {% if background_image in background_image_options|keys %}
     <div class="bg__sprites">
-    {% for sprite in sprites %}
+    {% for sprite in background_image_options[background_image] %}
       <div class="bg__sprite bg__sprite--{{sprite}} bg__sprite--{{loop.index}}">
 		    {% include '@psu-ooe/sprite/sprite.twig' with { name: sprite } only %}
 		  </div>

--- a/packages/background-container/package.json
+++ b/packages/background-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/background-container",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Provides a container that supports background sprites.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/background-container/background-container.twig
+++ b/packages/patternlab/source/patterns/molecules/background-container/background-container.twig
@@ -143,7 +143,7 @@
 
   {% set overflowing_content %}
     <div style="padding: 0 4rem">
-      <h2 style="color:black;margin-top:-10rem;margin-bottom:5rem;">I'm overflowing!!!</h2>
+      <h2 style="margin-top:-10rem;margin-bottom:5rem;">I'm overflowing!!!</h2>
       <h3>Overflowing content</h3>
       <p>This content is overflowing!</p>
     </div>
@@ -151,7 +151,7 @@
 
   <div style="max-width:119rem;padding:0 4rem;margin-top:6rem;">
     {% include '@psu-ooe/background-container/background-container.twig' with {
-      color: 'primary-blue',
+      color: 'beaver-blue',
       background_image: 'shield:right',
       content: overflowing_content
     } only %}

--- a/packages/patternlab/source/patterns/molecules/background-container/background-container.twig
+++ b/packages/patternlab/source/patterns/molecules/background-container/background-container.twig
@@ -34,8 +34,18 @@
     </div>
 {% endset %}
 <style>
-    .bg--primary-blue h3, .bg--primary-blue p { color: #fff !important; }
-    .bg--beaver-blue h3, .bg--beaver-blue p { color: #fff !important; }
+  /* @TODO: Remove when text auto-contrasts globally */
+
+  [data-light] {
+    --bg-demo-text-color: var(--text-color--dark);
+  }
+  [data-dark] {
+    --bg-demo-text-color: var(--text-color--light);
+  }
+
+  .bg-demo h3, .bg-demo p {
+    color: var(--bg-demo-text-color);
+  }
 </style>
 {% set colors = ['light-grey', 'beaver-blue'] %}
 {% set backgrounds = [
@@ -50,98 +60,100 @@
   'shield:program-page-banner-top',
   'shield:program-page-at-a-glance',
 ] %}
-{% for color in colors %}
-    {% for background in backgrounds %}
-      	<h2>{{ color }} {{ background }} (Full Width Background)</h2>
-          {% include '@psu-ooe/background-container/background-container.twig' with {
-              color: color,
-              background_image: background,
-              content: unbound_short_content
-          } only %}
-          <br />
-          <br />
-          {% include '@psu-ooe/background-container/background-container.twig' with {
-              color: color,
-              background_image: background,
-              content: unbound_tall_content
-          } only %}
-          <br />
-          <br />
-          {% include '@psu-ooe/background-container/background-container.twig' with {
-              color: color,
-              background_image: background,
-              width: 'narrow',
-              content: unbound_short_narrow_content
-          } only %}
-          <br />
-          <br />
-          {% include '@psu-ooe/background-container/background-container.twig' with {
-              color: color,
-              background_image: background,
-              width: 'narrow',
-              content: unbound_tall_narrow_content
-          } only %}
-          <br />
-          <br />
-    {% endfor %}
-{% endfor %}
+<div class="bg-demo">
+  {% for color in colors %}
+      {% for background in backgrounds %}
+          <h2>{{ color }} {{ background }} (Full Width Background)</h2>
+            {% include '@psu-ooe/background-container/background-container.twig' with {
+                color: color,
+                background_image: background,
+                content: unbound_short_content
+            } only %}
+            <br />
+            <br />
+            {% include '@psu-ooe/background-container/background-container.twig' with {
+                color: color,
+                background_image: background,
+                content: unbound_tall_content
+            } only %}
+            <br />
+            <br />
+            {% include '@psu-ooe/background-container/background-container.twig' with {
+                color: color,
+                background_image: background,
+                width: 'narrow',
+                content: unbound_short_narrow_content
+            } only %}
+            <br />
+            <br />
+            {% include '@psu-ooe/background-container/background-container.twig' with {
+                color: color,
+                background_image: background,
+                width: 'narrow',
+                content: unbound_tall_narrow_content
+            } only %}
+            <br />
+            <br />
+      {% endfor %}
+  {% endfor %}
 
-{% for color in colors %}
-    {% for background in backgrounds %}
-      	<h2>{{ color }} {{ background }} (Limited Width Background)</h2>
-            <div style="max-width:119rem;padding:0 4rem;margin:auto;">
-                {% include '@psu-ooe/background-container/background-container.twig' with {
-                    color: color,
-                    background_image: background,
-                    content: short_content
-                } only %}
-            </div>
-            <br />
-            <br />
-            <div style="max-width:119rem;padding:0 4rem;margin:auto;">
-                {% include '@psu-ooe/background-container/background-container.twig' with {
-                    color: color,
-                    background_image: background,
-                    content: tall_content
-                } only %}
-            </div>
-            <br />
-            <br />
-            <div style="max-width:95rem;padding:0 4rem;margin:auto;">
-                {% include '@psu-ooe/background-container/background-container.twig' with {
-                    color: color,
-                    background_image: background,
-                    width: 'narrow',
-                    content: short_content
-                } only %}
-            </div>
-            <br />
-            <br />
-            <div style="max-width:95rem;padding:0 4rem;margin:auto;">
-                {% include '@psu-ooe/background-container/background-container.twig' with {
-                    color: color,
-                    background_image: background,
-                    width: 'narrow',
-                    content: tall_content
-                } only %}
-            </div>
-            <br />
-            <br />
-    {% endfor %}
-{% endfor %}
+  {% for color in colors %}
+      {% for background in backgrounds %}
+          <h2>{{ color }} {{ background }} (Limited Width Background)</h2>
+              <div style="max-width:119rem;padding:0 4rem;margin:auto;">
+                  {% include '@psu-ooe/background-container/background-container.twig' with {
+                      color: color,
+                      background_image: background,
+                      content: short_content
+                  } only %}
+              </div>
+              <br />
+              <br />
+              <div style="max-width:119rem;padding:0 4rem;margin:auto;">
+                  {% include '@psu-ooe/background-container/background-container.twig' with {
+                      color: color,
+                      background_image: background,
+                      content: tall_content
+                  } only %}
+              </div>
+              <br />
+              <br />
+              <div style="max-width:95rem;padding:0 4rem;margin:auto;">
+                  {% include '@psu-ooe/background-container/background-container.twig' with {
+                      color: color,
+                      background_image: background,
+                      width: 'narrow',
+                      content: short_content
+                  } only %}
+              </div>
+              <br />
+              <br />
+              <div style="max-width:95rem;padding:0 4rem;margin:auto;">
+                  {% include '@psu-ooe/background-container/background-container.twig' with {
+                      color: color,
+                      background_image: background,
+                      width: 'narrow',
+                      content: tall_content
+                  } only %}
+              </div>
+              <br />
+              <br />
+      {% endfor %}
+  {% endfor %}
 
-{% set overflowing_content %}
-  <div style="padding: 0 4rem">
-    <h2 style="color:black;margin-top:-10rem;margin-bottom:5rem;">I'm overflowing!!!</h2>
-    <h3>Overflowing content</h3>
-    <p>This content is overflowing!</p>
+  {% set overflowing_content %}
+    <div style="padding: 0 4rem">
+      <h2 style="color:black;margin-top:-10rem;margin-bottom:5rem;">I'm overflowing!!!</h2>
+      <h3>Overflowing content</h3>
+      <p>This content is overflowing!</p>
+    </div>
+  {% endset %}
+
+  <div style="max-width:119rem;padding:0 4rem;margin-top:6rem;">
+    {% include '@psu-ooe/background-container/background-container.twig' with {
+      color: 'primary-blue',
+      background_image: 'shield:right',
+      content: overflowing_content
+    } only %}
   </div>
-{% endset %}
-
-<div style="max-width:119rem;padding:0 4rem;margin-top:6rem;">
-  {% include '@psu-ooe/background-container/background-container.twig' with {
-    color: 'primary-blue',
-    background_image: 'shield:right',
-    content: overflowing_content
-  } only %}
 </div>

--- a/packages/patternlab/source/patterns/molecules/background-container/background-container~nested.twig
+++ b/packages/patternlab/source/patterns/molecules/background-container/background-container~nested.twig
@@ -1,11 +1,12 @@
 {% set content %}
   <div style="padding:10rem;">
-    <p>I'm in pretty deep here...</p>
+    <p>I'm in over my head!</p>
   </div>
 {% endset %}
 
 {% set third_generation %}
   <div style="padding:10rem;">
+    <p>Getting deeper...</p>
     {% include '@psu-ooe/background-container/background-container.twig' with {
         color: 'beaver-blue',
         background_image: 'shield:topleft-bottomright',
@@ -16,6 +17,7 @@
 
 {% set second_generation %}
   <div style="padding:10rem;">
+    <p>Just on the fringes!</p>
     {% include '@psu-ooe/background-container/background-container.twig' with {
       color: 'light-grey',
       background_image: 'shield:right',
@@ -24,7 +26,7 @@
   </div>
 {% endset %}
 
-<div style="text-align:center; color:#fff">
+<div class="bg-demo" style="text-align:center; color:#fff">
   {% include '@psu-ooe/background-container/background-container.twig' with {
     color: 'beaver-blue',
     background_image: 'shield:left',

--- a/packages/patternlab/source/patterns/molecules/background-container/background-container~nested.twig
+++ b/packages/patternlab/source/patterns/molecules/background-container/background-container~nested.twig
@@ -26,7 +26,7 @@
   </div>
 {% endset %}
 
-<div class="bg-demo" style="text-align:center; color:#fff">
+<div class="bg-demo" style="text-align:center;">
   {% include '@psu-ooe/background-container/background-container.twig' with {
     color: 'beaver-blue',
     background_image: 'shield:left',


### PR DESCRIPTION
# Description:
In order to support auto-contrasting, background containers must add their lightness context. The change here is that either `data-light` or `data-dark` is added to the background container based on what the background color is.

## Metadata
### Adobe XD Link
  https://xd.adobe.com/view/299d9ee7-36e8-4b29-8fcb-6927d8636dca-7cce/ - see "CTA block (full width without image)"

### Review environment Link
  https://developers.outreach.psu.edu/background-container-contexts/?p=viewall-molecules-background-container -- The examples are a step closer to needing no additional design scaffolding.  As soon as the base text styles support auto-contrasting, no scaffolding will be needed at all for the examples here...
![image](https://github.com/PSU-OOE/components/assets/105240977/81f68525-a340-4e47-aa57-6002893483e6)
