### PR TITLE
Add color contexts to overlays

### DIFF
--- a/packages/overlay/overlay.twig
+++ b/packages/overlay/overlay.twig
@@ -1,24 +1,19 @@
-{% set classes = ['overlay'] %}
+{% set color_profiles = {
+  'blue-gradient': 'dark',
+  'beaver-blue': 'dark',
+} %}
 
-{% if overlay_bg_color %}
-  {% set classes = classes|merge(['overlay--' ~ overlay_bg_color ]) %}
-{% endif %}
-
-{% if column_width %}
-  {% set classes = classes|merge(['overlay--column-width-' ~ column_width ]) %}
-{% endif %}
-
-{% if overlay_width %}
-  {% set classes = classes|merge(['overlay--content-width-' ~ overlay_width ]) %}
-{% endif %}
-
-{% if background_position %}
-  {% set classes = classes|merge(['overlay--background-position--' ~ background_position ]) %}
-{% endif %}
+{% set classes = [
+  'overlay',
+  overlay_bg_color in color_profiles|keys ? 'overlay--' ~ overlay_bg_color,
+  column_width in ['narrow'] ? 'overlay--column-width-' ~ column_width,
+  overlay_width in ['wide'] ? 'overlay--content-width-' ~ overlay_width,
+  background_position in ['top-left', 'top-right', 'center-left', 'center-center', 'center-right', 'bottom-left', 'bottom-center', 'bottom-right'] ? 'overlay--background-position--' ~ background_position,
+] %}
 
 <div class="{{ classes|join(' ') }}">
   <div class="overlay__image"> {{ image }} </div>
   <div class="overlay__column">
-    <div class="overlay__content"> {{ content }} </div>
+    <div class="overlay__content" data-{{ color_profiles|keys ? color_profiles[overlay_bg_color] : 'light' }}> {{ content }} </div>
   </div>
 </div>

--- a/packages/overlay/overlay.twig
+++ b/packages/overlay/overlay.twig
@@ -9,7 +9,7 @@
   column_width in ['narrow'] ? 'overlay--column-width-' ~ column_width,
   overlay_width in ['wide'] ? 'overlay--content-width-' ~ overlay_width,
   background_position in ['top-left', 'top-right', 'center-left', 'center-center', 'center-right', 'bottom-left', 'bottom-center', 'bottom-right'] ? 'overlay--background-position--' ~ background_position,
-] %}
+]|filter(class => class is not empty) %}
 
 <div class="{{ classes|join(' ') }}">
   <div class="overlay__image"> {{ image }} </div>

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/overlay",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Provides an overlay implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/overlay/src/scss/styles.scss
+++ b/packages/overlay/src/scss/styles.scss
@@ -34,7 +34,7 @@
   }
 
   .overlay__content {
-    background: $white;
+    background: var(--white);
     width: auto;
     padding: _rem(2);
 
@@ -62,11 +62,11 @@
   }
 
   &--beaver-blue .overlay__content {
-    background: $beaver-blue;
+    background: var(--beaver-blue);
   }
 
   &--blue-gradient .overlay__content {
-    background: linear-gradient(to right, $nittany-navy, $beaver-blue);
+    background: linear-gradient(to right, var(--nittany-navy), var(--beaver-blue));
   }
 
   &--column-width-narrow {

--- a/packages/overlay/src/scss/styles.scss
+++ b/packages/overlay/src/scss/styles.scss
@@ -50,28 +50,23 @@
       align-self: center;
       z-index: 1;
     }
+
+    // @TODO: Remove this when text auto-contrasts globally.
+    &[data-dark] {
+      color: var(--white);
+
+      & > * {
+        color: var(--white);
+      }
+    }
   }
 
-  &--beaver-blue {
-    .overlay__content {
-      background: $beaver-blue;
-      color: $white;
-    }
-    // because quotes are currently nested in here
-    .overlay__content > * {
-      color: $white;
-    }
+  &--beaver-blue .overlay__content {
+    background: $beaver-blue;
   }
 
-  &--blue-gradient {
-    .overlay__content {
-      background: linear-gradient(to right, $nittany-navy, $beaver-blue);
-      color: $white;
-    }
-    // because quotes are currently nested in here
-    .overlay__content > * {
-      color: $white;
-    }
+  &--blue-gradient .overlay__content {
+    background: linear-gradient(to right, $nittany-navy, $beaver-blue);
   }
 
   &--column-width-narrow {

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/overlay/_overlay.md
+++ b/packages/patternlab/source/patterns/molecules/overlay/_overlay.md
@@ -1,0 +1,37 @@
+# Variables
+| Variable            | Type   | Required | Description                                               |
+|---------------------|--------|----------|-----------------------------------------------------------|
+| content             | string | true     | The content to render inside the overlay container.       |
+| overlay_bg_color    | string | false    | May match a documented background color modifier (below). |
+| column_width        | string | false    | May match a documented column with modifier (below).      |
+| overlay_width       | string | false    | May match a documented overlay width modifier (below).    |
+| background_position | string | false    | May match a documented position modifier (below).         |
+
+## Colors
+| Color         | Description                          |
+|---------------|--------------------------------------|
+| blue-gradient | Displays a blue gradient background. |
+| beaver-blue   | Displays a beaver-blue background.   |
+
+## Column widths
+| Width  | Description                          |
+|--------|--------------------------------------|
+| narrow | Displays with a narrow column width. |
+
+## Overlay widths
+| Width | Description                         |
+|-------|-------------------------------------|
+| wide  | Displays with a wide overlay width. |
+
+## Background positions
+| Position      | Description                                                |
+|---------------|------------------------------------------------------------|
+| top-left      | Anchors the background image focal point to top-left.      |
+| top-center    | Anchors the background image focal point to top-center.    |
+| top-right     | Anchors the background image focal point to top-right.     |
+| center-left   | Anchors the background image focal point to center-left.   |
+| center-center | Anchors the background image focal point to center-center. |
+| center-right  | Anchors the background image focal point to center-right.  |
+| bottom-left   | Anchors the background image focal point to bottom-left.   |
+| bottom-center | Anchors the background image focal point to bottom-center. |
+| bottom-right  | Anchors the background image focal point to bottom-right.  |


### PR DESCRIPTION
# Description:
Much like the background containers pull request, this one adds `data-dark` or `data-light` to the content box:
![image](https://github.com/PSU-OOE/components/assets/105240977/1fe8a4ec-442e-4994-a93a-a8d741f90422)

By default, the content box is explicitly set to white, hence the ternary in the `{% if %}` expression.  The intent is to remove the forced foreground coloration when possible so we aren't "reaching inside" subordinate components via the `> *` mechanism.

## Metadata

### Adobe XD Link
  https://xd.adobe.com/view/299d9ee7-36e8-4b29-8fcb-6927d8636dca-7cce/ -- see the "CTA block (full width with image)" spec

### Review environment Link
  https://developers.outreach.psu.edu/overlay-contexts/?p=viewall-molecules-overlay -- no changes to examples; just added pattern docs that were previously missing.