### PR TITLE
Upgrade to supported NodeJS release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
       - run: echo "npmRegistries:" >> .yarnrc.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'   
+          node-version: '22.x'
       - run: echo "npmRegistries:" >> .yarnrc.yml
       - run: echo '  "https://npm.pkg.github.com":' >> .yarnrc.yml
       - run: echo -n '    npmAuthToken:' >> .yarnrc.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '20.x'
       - run: echo "npmRegistries:" >> .yarnrc.yml
       - run: echo '  "https://npm.pkg.github.com":' >> .yarnrc.yml
       - run: echo -n '    npmAuthToken:' >> .yarnrc.yml

--- a/.github/workflows/push_to_s3.yml
+++ b/.github/workflows/push_to_s3.yml
@@ -9,8 +9,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
       - run: yarn install
@@ -18,7 +18,7 @@ jobs:
       - run: npm run package
       - run: ./node_modules/.bin/patternlab build --config packages/patternlab/patternlab-config.json
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/push_to_s3.yml
+++ b/.github/workflows/push_to_s3.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '22.x'
       - run: yarn install
       - run: yarn workspaces foreach install
       - run: npm run package

--- a/.github/workflows/push_to_s3.yml
+++ b/.github/workflows/push_to_s3.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '20.x'
       - run: yarn install
       - run: yarn workspaces foreach install
       - run: npm run package

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"


### PR DESCRIPTION
# Description:
Node 16 is end of life; upgrade to the LTS-to-be.
- [x] Just upgrades to actions are required for now (woohoo)
- [x] Bump PL version to test the package publishing action

There are some unsupported gulp things that we should probably open other issues for too.

## Metadata
### Workfront Task Link
  https://pennstateoutreach.my.workfront.com/task/664260f3005036e279540deaff057151/overview