### PR TITLE
Add error border for file inputs

### DIFF
--- a/packages/input-file/package.json
+++ b/packages/input-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/input-file",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides file element styles.",
   "publishConfig": {
     "access": "public",

--- a/packages/input-file/src/scss/styles.scss
+++ b/packages/input-file/src/scss/styles.scss
@@ -5,6 +5,7 @@ input[type="file"] {
   cursor: pointer;
   width: var(--form-element-width);
   border-radius: var(--form-element-border-radius--rounded);
+  border-width: _rem(.1);
   font-family: var(--form-element-font-family);
   font-weight: var(--form-element-font-weight);
   color: var(--form-element-text-color);
@@ -24,6 +25,11 @@ input[type="file"] {
     line-height: var(--form-element-line-height);
     padding: var(--form-element-padding--vertical) var(--form-element-padding--horizontal);
     transition: background-color var(--transition-duration--default) linear;
+  }
+
+  &.error {
+    border-color: var(--error-red);
+    border-style: solid;
   }
 
   &:focus {

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/atoms/file/file~error-on-dark.twig
+++ b/packages/patternlab/source/patterns/atoms/file/file~error-on-dark.twig
@@ -1,0 +1,10 @@
+{% set file %}
+  <div data-dark>
+    <input type="file" name="file_single_on_dark" id="file_single_on_dark" class="error"><label class="visually-hidden" for="file_single_on_dark">Demo file single on dark background</label>
+  </div>
+{% endset %}
+
+{% include '@psu-ooe/callout/callout.twig' with {
+  content: file,
+  background: 'blue',
+} only %}

--- a/packages/patternlab/source/patterns/atoms/file/file~error.twig
+++ b/packages/patternlab/source/patterns/atoms/file/file~error.twig
@@ -1,0 +1,7 @@
+{% set file %}
+  <input type="file" name="file" id="file" class="error"><label class="visually-hidden" for="file">Demo file</label>
+{% endset %}
+
+{% include '@psu-ooe/callout/callout.twig' with {
+  content: file,
+} only %}


### PR DESCRIPTION
# Description:

Version 1.0.0 of the file input component is missing error state styling.

## Metadata

### Adobe XD Link

https://xd.adobe.com/view/c3926599-fc79-48ce-9ab2-cb4e483bfc33-96c1/

### Review environment Link

https://developers.outreach.psu.edu/file-input-error-state/?p=viewall-atoms-file