### PR TITLE
Adding new 'futures calling' green color to visual styles

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/base",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "The base styles for the OOE design system.",
   "ooe": {
     "namespace": "global"

--- a/packages/base/src/scss/variables/_colors.scss
+++ b/packages/base/src/scss/variables/_colors.scss
@@ -32,6 +32,8 @@
   --pa-link: #{ $pa-link };
   --pa-link-light: #{ $pa-link-light };
 
+  --futures-calling: #99cc00;
+
   // Tile nav
   --tile-nav-image-overlay: #{ $tile-nav-image-overlay };
   --tile-nav-active: #{ $tile-nav-active };

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/visual-styles/colors/color-system.twig
+++ b/packages/patternlab/source/patterns/visual-styles/colors/color-system.twig
@@ -25,7 +25,7 @@
     'error red': { hex_code:  '#dd3636', scss_variable: '$error-red' },
     'primary blue (DEPRECIATED)': { hex_code:  '#0064bf', scss_variable: '$primary-blue' },
     'true blue (DEPRECIATED)': { hex_code:  '#0056ae', scss_variable: '$true-blue' },
-    'futures calling': { hex_code: '#99cc00' }
+    'futures calling': { hex_code: '#99cc00', scss_variable: 'dolla bills' }
 }
 %}
 

--- a/packages/patternlab/source/patterns/visual-styles/colors/color-system.twig
+++ b/packages/patternlab/source/patterns/visual-styles/colors/color-system.twig
@@ -24,7 +24,8 @@
     'invent orange': { hex_code:  '#e98300', scss_variable: '$invent-orange' },
     'error red': { hex_code:  '#dd3636', scss_variable: '$error-red' },
     'primary blue (DEPRECIATED)': { hex_code:  '#0064bf', scss_variable: '$primary-blue' },
-    'true blue (DEPRECIATED)': { hex_code:  '#0056ae', scss_variable: '$true-blue' }
+    'true blue (DEPRECIATED)': { hex_code:  '#0056ae', scss_variable: '$true-blue' },
+    'futures calling': { hex_code: '#99cc00' }
 }
 %}
 

--- a/packages/patternlab/source/patterns/visual-styles/colors/color-system.twig
+++ b/packages/patternlab/source/patterns/visual-styles/colors/color-system.twig
@@ -25,7 +25,7 @@
     'error red': { hex_code:  '#dd3636', scss_variable: '$error-red' },
     'primary blue (DEPRECIATED)': { hex_code:  '#0064bf', scss_variable: '$primary-blue' },
     'true blue (DEPRECIATED)': { hex_code:  '#0056ae', scss_variable: '$true-blue' },
-    'futures calling': { hex_code: '#99cc00', scss_variable: 'dolla bills' }
+    'futures calling': { hex_code: '#99cc00', scss_variable: 'n/a' }
 }
 %}
 


### PR DESCRIPTION
Description:
Adding the new 'futures calling' green color to visual styles.

Adobe XD Link
https://xd.adobe.com/view/340bdfea-ba4b-430c-b13b-102363a8f505-6158/

Review environment Link
https://developers.outreach.psu.edu/new-color/?p=viewall-visual-styles-colors