### PR TITLE
276 resolve sass deprecations in legacy table styles

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/base",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "The base styles for the OOE design system.",
   "ooe": {
     "namespace": "global"

--- a/packages/base/src/scss/_tables.scss
+++ b/packages/base/src/scss/_tables.scss
@@ -79,13 +79,12 @@ table {
 table.small-only {
 
   display: table;
+  margin-top: _rem(1);
+  border-top: _rem(.1) solid var(--medium-grey);
 
   @include bp(m) {
     display: none;
   }
-
-  margin-top: _rem(1);
-  border-top: _rem(.1) solid var(--medium-grey);
 
   tr {
     border: _rem(.1) solid var(--medium-grey);
@@ -122,12 +121,11 @@ table.small-only {
 
 table.large-only {
   display: none;
+  margin: _rem(3) 0;
 
   @include bp(m) {
     display: table;
   }
-
-  margin: _rem(3) 0;
 }
 
 tr:not(:first-of-type) .st-head-row {


### PR DESCRIPTION
# Description:
A new deprecation in the latest version of SASS needs to be resolved.  Basically, any CSS directives must come before mixins.

Tables were the only offender here (go figure, the last of Eastern Standard :smile:.