### PR TITLE
290 remove heading overlines from all announcement examples

### DIFF
--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/organisms/announcement/announcement~emergency.twig
+++ b/packages/patternlab/source/patterns/organisms/announcement/announcement~emergency.twig
@@ -1,5 +1,5 @@
 {% set content %}
-  <h2>Why use an emergency announcement?</h2>
+  <h2 class="heading--no-overline">Why use an emergency announcement?</h2>
   <p>Using an emergency announcement is crucial for effectively communicating urgent information to the public during a crisis or critical event. In situations such as natural disasters, public safety threats, or health emergencies, timely and clear announcements can provide essential guidance, instructions, and updates to help individuals make informed decisions. These announcements can facilitate the dissemination of evacuation orders, safety reminders, or shelter locations, ensuring that communities are well-informed and can reduce panic and confusion.</p>
   <a href="#">More information</a>
 {% endset %}

--- a/packages/patternlab/source/patterns/organisms/announcement/announcement~notice.twig
+++ b/packages/patternlab/source/patterns/organisms/announcement/announcement~notice.twig
@@ -1,5 +1,5 @@
 {% set content %}
-  <h2>Why use a notice announcement?</h2>
+  <h2 class="heading--no-overline">Why use a notice announcement?</h2>
   <p>Notice announcements serve as a formal means to inform individuals about events, changes, deadlines, or policies, ensuring that everyone is on the same page. An announcement can enhance transparency within an organization or community, fostering trust and engagement. They provide a clear and concise format that can be easily referenced, helping to reduce misunderstandings and keep everyone informed. By utilizing notice announcements, organizations can streamline communication, promote accountability, and encourage timely responses from recipients.</p>
   <a href="#">More information</a>
 {% endset %}

--- a/packages/patternlab/source/patterns/organisms/announcement/announcement~warning.twig
+++ b/packages/patternlab/source/patterns/organisms/announcement/announcement~warning.twig
@@ -1,5 +1,5 @@
 {% set content %}
-  <h2>Why use a warning announcement?</h2>
+  <h2 class="heading--no-overline">Why use a warning announcement?</h2>
   <p>Using a warning announcement for non-life-threatening circumstances can be crucial in maintaining public awareness and preparedness. By issuing such warnings, authorities can effectively disseminate important information that helps individuals make informed decisions and take necessary precautions to mitigate risks. Examples of warnings include severe weather events or ongoing public health concerns. Ultimately, while the event may not be life-threatening, the potential for disruption and inconvenience underscores the importance of timely and clear warnings.</p>
   <a href="#">More information</a>
 {% endset %}


### PR DESCRIPTION
Description:
Removing h2 overlines from announcement twig examples.

Review environment Link
https://developers.outreach.psu.edu/290-remove-heading-overlines-from-all-announcement-examples/?p=viewall-organisms-announcement
