### PR TITLE
289 add minimum widths to various things

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/accordion",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Provides an accessible accordion implementation.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/accordion/src/scss/styles.scss
+++ b/packages/accordion/src/scss/styles.scss
@@ -1,6 +1,7 @@
 @import "../../../base/src/scss/imports/_variables.scss";
 
 .accordion {
+  min-width: 15rem;
 
   &:not(.accordion--borderless) {
 

--- a/packages/accordion/src/scss/styles.scss
+++ b/packages/accordion/src/scss/styles.scss
@@ -1,7 +1,7 @@
 @import "../../../base/src/scss/imports/_variables.scss";
 
 .accordion {
-  min-width: 15rem;
+  min-width: _rem(15);
 
   &:not(.accordion--borderless) {
 

--- a/packages/basic-tile/package.json
+++ b/packages/basic-tile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/basic-tile",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Provides a basic tile component.",
   "publishConfig": {
     "access": "public",

--- a/packages/basic-tile/src/scss/styles.scss
+++ b/packages/basic-tile/src/scss/styles.scss
@@ -1,6 +1,7 @@
 @import "../../../base/src/scss/imports/variables";
 
 .basic-tile {
+  min-width: 12rem;
   font-size: var(--font-size--default);
   line-height: var(--line-height--xsnug);
   font-family: var(--font-family--default);

--- a/packages/basic-tile/src/scss/styles.scss
+++ b/packages/basic-tile/src/scss/styles.scss
@@ -1,7 +1,7 @@
 @import "../../../base/src/scss/imports/variables";
 
 .basic-tile {
-  min-width: 12rem;
+  min-width: _rem(12);
   font-size: var(--font-size--default);
   line-height: var(--line-height--xsnug);
   font-family: var(--font-family--default);

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/card",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Provides a card implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/card/src/scss/styles.scss
+++ b/packages/card/src/scss/styles.scss
@@ -2,6 +2,7 @@
 
 .card {
   position: relative;
+  min-width: 15rem;
 
   &:focus-within,
   &:hover {

--- a/packages/card/src/scss/styles.scss
+++ b/packages/card/src/scss/styles.scss
@@ -2,7 +2,7 @@
 
 .card {
   position: relative;
-  min-width: 15rem;
+  min-width: _rem(15);
 
   &:focus-within,
   &:hover {

--- a/packages/credential/package.json
+++ b/packages/credential/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/credential",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Provides a credential component.",
   "publishConfig": {
     "access": "public",

--- a/packages/credential/src/scss/styles.scss
+++ b/packages/credential/src/scss/styles.scss
@@ -1,7 +1,7 @@
 @import "../../../base/src/scss/imports/variables";
 
 .credential {
-  min-width: 12rem;
+  min-width: _rem(12);
   display: flex;
   flex-flow: row nowrap;
   color: var(--slate);

--- a/packages/credential/src/scss/styles.scss
+++ b/packages/credential/src/scss/styles.scss
@@ -1,6 +1,7 @@
 @import "../../../base/src/scss/imports/variables";
 
 .credential {
+  min-width: 12rem;
   display: flex;
   flex-flow: row nowrap;
   color: var(--slate);

--- a/packages/cta/package.json
+++ b/packages/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/cta",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Provides a CTA button.",
   "publishConfig": {
     "access": "public",

--- a/packages/cta/src/scss/_cta-group.scss
+++ b/packages/cta/src/scss/_cta-group.scss
@@ -1,5 +1,6 @@
 .cta-group {
   display: flex;
+  min-width: 10rem;
 
   &--align-right {
     text-align: right;

--- a/packages/cta/src/scss/_cta-group.scss
+++ b/packages/cta/src/scss/_cta-group.scss
@@ -1,6 +1,6 @@
 .cta-group {
   display: flex;
-  min-width: 10rem;
+  min-width: _rem(10);
 
   &--align-right {
     text-align: right;

--- a/packages/infographic/package.json
+++ b/packages/infographic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/infographic",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides an infographic.",
   "publishConfig": {
     "access": "public",

--- a/packages/infographic/src/scss/styles.scss
+++ b/packages/infographic/src/scss/styles.scss
@@ -2,7 +2,7 @@
 @import "../../../base/src/scss/imports/layout";
 
 .infographic {
-  min-width: 23rem;
+  min-width: _rem(23);
   display: flex;
   flex-wrap: nowrap;
   margin: 0;

--- a/packages/infographic/src/scss/styles.scss
+++ b/packages/infographic/src/scss/styles.scss
@@ -2,6 +2,7 @@
 @import "../../../base/src/scss/imports/layout";
 
 .infographic {
+  min-width: 23rem;
   display: flex;
   flex-wrap: nowrap;
   margin: 0;

--- a/packages/intro-form/package.json
+++ b/packages/intro-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/intro-form",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Provides a specialized container for presenting a form with accompanying intro content.",
   "publishConfig": {
     "access": "public",

--- a/packages/intro-form/src/scss/styles.scss
+++ b/packages/intro-form/src/scss/styles.scss
@@ -2,7 +2,7 @@
 @import '../../../base/src/scss/imports/layout';
 
 .intro-form {
-  min-width: 20rem;
+  min-width: _rem(20);
   position: relative;
   padding: _rem(3) 0;
 

--- a/packages/intro-form/src/scss/styles.scss
+++ b/packages/intro-form/src/scss/styles.scss
@@ -2,6 +2,7 @@
 @import '../../../base/src/scss/imports/layout';
 
 .intro-form {
+  min-width: 20rem;
   position: relative;
   padding: _rem(3) 0;
 

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/overlay",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Provides an overlay implementation.",
   "publishConfig": {
     "access": "public",

--- a/packages/overlay/src/scss/styles.scss
+++ b/packages/overlay/src/scss/styles.scss
@@ -2,7 +2,7 @@
 @import "../../../base/src/scss/imports/layout";
 
 .overlay {
-  min-width: 20rem;
+  min-width: _rem(20);
   
   @include bp(s) {
     position: relative;

--- a/packages/overlay/src/scss/styles.scss
+++ b/packages/overlay/src/scss/styles.scss
@@ -2,6 +2,8 @@
 @import "../../../base/src/scss/imports/layout";
 
 .overlay {
+  min-width: 20rem;
+  
   @include bp(s) {
     position: relative;
     min-height: _rem(50);

--- a/packages/parallel-navigation-item/package.json
+++ b/packages/parallel-navigation-item/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/parallel-navigation-item",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Provides a parallel navigation item component.",
   "publishConfig": {
     "access": "public",

--- a/packages/parallel-navigation-item/src/scss/styles.scss
+++ b/packages/parallel-navigation-item/src/scss/styles.scss
@@ -2,6 +2,8 @@
 @import "../../../base/src/scss/imports/layout";
 
 .parallel-navigation-item {
+  min-width: 10rem;
+  
   &__link {
     color: var(--nittany-navy);
     display: flex;

--- a/packages/parallel-navigation-item/src/scss/styles.scss
+++ b/packages/parallel-navigation-item/src/scss/styles.scss
@@ -2,7 +2,7 @@
 @import "../../../base/src/scss/imports/layout";
 
 .parallel-navigation-item {
-  min-width: 10rem;
+  min-width: _rem(10);
   
   &__link {
     color: var(--nittany-navy);

--- a/packages/skip-link/package.json
+++ b/packages/skip-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/skip-link",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Provides a skip link element.",
   "publishConfig": {
     "access": "public",

--- a/packages/skip-link/src/scss/styles.scss
+++ b/packages/skip-link/src/scss/styles.scss
@@ -1,7 +1,7 @@
 @import "../../../base/src/scss/imports/variables";
 
 .skip-link {
-  min-width: 4rem;
+  min-width: _rem(4);
   padding: _rem(2) _rem(2.5);
   outline: _rem(0.2) solid $sky-blue;
   outline-offset: 0;

--- a/packages/skip-link/src/scss/styles.scss
+++ b/packages/skip-link/src/scss/styles.scss
@@ -1,6 +1,7 @@
 @import "../../../base/src/scss/imports/variables";
 
 .skip-link {
+  min-width: 4rem;
   padding: _rem(2) _rem(2.5);
   outline: _rem(0.2) solid $sky-blue;
   outline-offset: 0;

--- a/packages/social-icon/package.json
+++ b/packages/social-icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/social-icon",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Provides a social icon link molecule.",
   "publishConfig": {
     "access": "public",

--- a/packages/social-icon/src/scss/styles.scss
+++ b/packages/social-icon/src/scss/styles.scss
@@ -1,6 +1,7 @@
 @import "../../../base/src/scss/imports/variables";
 
 .social-icon {
+  min-width: 4.4rem;
   display: inline-block;
   transition: .3s opacity ease-in;
   opacity: .8;

--- a/packages/social-icon/src/scss/styles.scss
+++ b/packages/social-icon/src/scss/styles.scss
@@ -1,7 +1,7 @@
 @import "../../../base/src/scss/imports/variables";
 
 .social-icon {
-  min-width: 4.4rem;
+  min-width: _rem(4.4);
   display: inline-block;
   transition: .3s opacity ease-in;
   opacity: .8;

--- a/packages/spinner/package.json
+++ b/packages/spinner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/spinner",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Provides a spinner component.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/spinner/src/scss/styles.scss
+++ b/packages/spinner/src/scss/styles.scss
@@ -1,7 +1,7 @@
 @import "../../../base/src/scss/imports/variables";
 
 .spinner {
-  min-width: 2rem;
+  min-width: _rem(2);
   position: relative;
   display: inline-block;
 

--- a/packages/spinner/src/scss/styles.scss
+++ b/packages/spinner/src/scss/styles.scss
@@ -1,6 +1,7 @@
 @import "../../../base/src/scss/imports/variables";
 
 .spinner {
+  min-width: 2rem;
   position: relative;
   display: inline-block;
 


### PR DESCRIPTION
Description:
These components need minimum widths put on their outer-most DOM element.
 Accordion Item: 15rem
 Basic Tile: 12rem
 Card: 15rem
 Credential: 12rem
 CTA Group: 10rem
 Infographic: 23rem
 Intro Form: 20rem
 Overlay: 20rem
 Parallel Navigation Item: 10rem
 Skip Link: 4rem
 Social Icon: 4.4rem
 Spinner: 2rem

Review environment Link
https://developers.outreach.psu.edu/289-add-minimum-widths-to-various-things/?p=all
