### PR TITLE
Be sure to pass width information through to the layout regions.

### DIFF
--- a/packages/layout-multi-col/package.json
+++ b/packages/layout-multi-col/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/layout-multi-col",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Common styles for multi-column layouts.",
   "publishConfig": {
     "access": "public",

--- a/packages/layout-multi-col/src/scss/styles.scss
+++ b/packages/layout-multi-col/src/scss/styles.scss
@@ -25,6 +25,7 @@
     margin-left: var(--layout-column-gap);
     margin-right: var(--layout-column-gap);
     flex: 1 1 calc((100% * (var(--region-weight, 0))) - (2 * var(--layout-column-gap)));
+    width: 100%;
 
     &--25 {
       --region-weight: .25;


### PR DESCRIPTION
# Description:
Region widths were set to `auto` previously.  This meant that child elements of layouts that relied upon the parent width broke.  One example is the `aspect-ratio` property...

To rectify, specify `width: 100%` on the region so that the calculated value is passed down.
