### PR TITLE
Prevent layout regions from overflowing when breaking to columns

### DIFF
--- a/packages/layout-multi-col/package.json
+++ b/packages/layout-multi-col/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/layout-multi-col",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Common styles for multi-column layouts.",
   "publishConfig": {
     "access": "public",

--- a/packages/layout-multi-col/src/scss/styles.scss
+++ b/packages/layout-multi-col/src/scss/styles.scss
@@ -25,7 +25,7 @@
     margin-left: var(--layout-column-gap);
     margin-right: var(--layout-column-gap);
     flex: 1 1 calc((100% * (var(--region-weight, 0))) - (2 * var(--layout-column-gap)));
-    width: 100%;
+    width: calc(100% - (2 * var(--layout-column-gap)));
 
     &--25 {
       --region-weight: .25;


### PR DESCRIPTION
# Description:
The negative margins thing seems to need some babysitting.  The max width of a layout region can't be 100%, it has to be 100% minus the negative margins applied.