### PR TITLE
Resolve Chrome 129 regression in background container

### DIFF
--- a/packages/background-container/background-container.twig
+++ b/packages/background-container/background-container.twig
@@ -34,5 +34,7 @@
     {% endfor %}
     </div>
   {% endif %}
-  {{ content }}
+  <div class="bg__content">
+    {{ content }}
+  </div>
 </div>

--- a/packages/background-container/package.json
+++ b/packages/background-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/background-container",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Provides a container that supports background sprites.",
   "ooe": {
     "namespace": "molecules"

--- a/packages/background-container/src/scss/styles.scss
+++ b/packages/background-container/src/scss/styles.scss
@@ -53,7 +53,11 @@
     position: absolute;
     overflow: hidden;
     inset: 0 0 0 0;
-    z-index: -1;
+  }
+
+  &__content {
+    position: relative;
+    z-index: 1;
   }
 
   @import "hub-geometric-topleft";


### PR DESCRIPTION
# Description:
For an unknown reason, Chrome 129's behavior seems to have changed regarding z-index management within containers.  Previously, we were pushing the sprites back by giving them a `z-index` value of `-1`.  In Chrome 129, that pushes them too far back.

To work around this, instead of pushing the sprites back, we pull the content ahead by giving it a positive z-index value.  This seems to make Chrome happy.

## Metadata

### Review environment Link
  https://developers.outreach.psu.edu/chrome-killin-me