### PR TITLE
Add missing details in patternlab; fix duplicate ID

### DIFF
--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.37",
+  "version": "2.0.38",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"
@@ -30,6 +30,7 @@
     "@psu-ooe/credential": "*",
     "@psu-ooe/cta": "*",
     "@psu-ooe/cta-tracking": "*",
+    "@psu-ooe/details": "*",
     "@psu-ooe/divider": "*",
     "@psu-ooe/drop-button": "*",
     "@psu-ooe/event-link": "*",

--- a/packages/patternlab/source/patterns/atoms/file/file~error-on-dark.twig
+++ b/packages/patternlab/source/patterns/atoms/file/file~error-on-dark.twig
@@ -1,6 +1,6 @@
 {% set file %}
   <div data-dark>
-    <input type="file" name="file_single_on_dark" id="file_single_on_dark" class="error"><label class="visually-hidden" for="file_single_on_dark">Demo file single on dark background</label>
+    <input type="file" name="file_error_on_dark" id="file_error_on_dark" class="error"><label class="visually-hidden" for="file_error_on_dark">Demo file single on dark background</label>
   </div>
 {% endset %}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,7 +1772,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@psu-ooe/details@workspace:packages/details":
+"@psu-ooe/details@*, @psu-ooe/details@workspace:packages/details":
   version: 0.0.0-use.local
   resolution: "@psu-ooe/details@workspace:packages/details"
   dependencies:
@@ -2245,6 +2245,7 @@ __metadata:
     "@psu-ooe/credential": "*"
     "@psu-ooe/cta": "*"
     "@psu-ooe/cta-tracking": "*"
+    "@psu-ooe/details": "*"
     "@psu-ooe/divider": "*"
     "@psu-ooe/drop-button": "*"
     "@psu-ooe/event-link": "*"


### PR DESCRIPTION
# Description:
I just re-ran the ghost inspector design system suites and there were a few fails.

1. The details package isn't installed on psu-ooe.github.io
2. There are duplicate IDs in the file upload examples.
