### PR TITLE
Fix nightly build by fixing dependencies

### DIFF
--- a/packages/expandable-section/package.json
+++ b/packages/expandable-section/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/expandable-section",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Provides an expandable section implementation.",
   "publishConfig": {
     "access": "public",
@@ -9,7 +9,7 @@
   "dependencies": {
     "@psu-ooe/auto-expansion": "^1.0",
     "@psu-ooe/base": "^2.2",
-    "@psu-ooe/cta": "^3.0",
+    "@psu-ooe/button": "^1.0",
     "@psu-ooe/slide-toggle": "^1.0"
   }
 }

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.42",
+  "version": "2.0.43",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"
@@ -22,6 +22,7 @@
     "@psu-ooe/bio": "*",
     "@psu-ooe/bio-collection": "*",
     "@psu-ooe/breadcrumbs": "*",
+    "@psu-ooe/button": "*",
     "@psu-ooe/callout": "*",
     "@psu-ooe/card": "*",
     "@psu-ooe/cards-list": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1684,7 +1684,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@psu-ooe/button@workspace:packages/button":
+"@psu-ooe/button@*, @psu-ooe/button@^1.0, @psu-ooe/button@workspace:packages/button":
   version: 0.0.0-use.local
   resolution: "@psu-ooe/button@workspace:packages/button"
   dependencies:
@@ -1780,7 +1780,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@psu-ooe/cta@*, @psu-ooe/cta@^3.0, @psu-ooe/cta@workspace:packages/cta":
+"@psu-ooe/cta@*, @psu-ooe/cta@workspace:packages/cta":
   version: 0.0.0-use.local
   resolution: "@psu-ooe/cta@workspace:packages/cta"
   dependencies:
@@ -1829,7 +1829,7 @@ __metadata:
   dependencies:
     "@psu-ooe/auto-expansion": ^1.0
     "@psu-ooe/base": ^2.2
-    "@psu-ooe/cta": ^3.0
+    "@psu-ooe/button": ^1.0
     "@psu-ooe/slide-toggle": ^1.0
   languageName: unknown
   linkType: soft
@@ -2254,6 +2254,7 @@ __metadata:
     "@psu-ooe/bio": "*"
     "@psu-ooe/bio-collection": "*"
     "@psu-ooe/breadcrumbs": "*"
+    "@psu-ooe/button": "*"
     "@psu-ooe/callout": "*"
     "@psu-ooe/card": "*"
     "@psu-ooe/cards-list": "*"


### PR DESCRIPTION
# Description:
The CTA/Button re-work introduced a dependency bug in the expandable section.  The CTA is no longer required, but instead the Button component is!

I've also added the button dependency to the patternlab package.

See failure at https://github.com/PSU-OOE/psu-ooe.github.io/actions/runs/12663863953/job/35291116917