### PR TITLE
Fix horizontal menu focus / hover color to use horizontal-menu-link-f…

### DIFF
--- a/packages/horizontal-menu/package.json
+++ b/packages/horizontal-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/horizontal-menu",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Provides a horizontal menu.",
   "publishConfig": {
     "access": "public",

--- a/packages/horizontal-menu/src/scss/styles.scss
+++ b/packages/horizontal-menu/src/scss/styles.scss
@@ -81,7 +81,7 @@
 
       &:focus-within, &:hover, &:has(+ [aria-expanded="true"]) {
         background: var(--horizontal-menu-link-active-background-color, var(--pa-link));
-        color: var(--horizontal-menu-link-active-foreground-color, var(--text-color));
+        color: var(--text-color);
         text-decoration: none;
       }
 
@@ -128,7 +128,7 @@
       }
 
       &:hover, &:focus-visible {
-        color: var(--horizontal-menu-link-foreground-color, var(--sky-blue));
+        color: var(--horizontal-menu-link-active-foreground-color, var(--sky-blue));
       }
 
       &:focus-visible {

--- a/packages/horizontal-menu/src/scss/styles.scss
+++ b/packages/horizontal-menu/src/scss/styles.scss
@@ -128,7 +128,7 @@
       }
 
       &:hover, &:focus-visible {
-        color: var(--accent-color-semantic, var(--sky-blue));
+        color: var(--horizontal-menu-link-foreground-color, var(--sky-blue));
       }
 
       &:focus-visible {


### PR DESCRIPTION
Fix horizontal menu styles to allow accent semantic colors from not leaking through to hover / focus menu link styles.
