### PR TITLE
Adjust line height placement on search and menu components.

### DIFF
--- a/packages/compact-menu/package.json
+++ b/packages/compact-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/compact-menu",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Provides a compact menu block.",
   "publishConfig": {
     "access": "public",

--- a/packages/compact-menu/src/scss/styles.scss
+++ b/packages/compact-menu/src/scss/styles.scss
@@ -32,6 +32,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    line-height: var(--line-height--nospace);
 
     &:is(:focus-visible > .compact-menu__toggle) {
       outline: _rem(.2) solid var(--focus-indicator-color);
@@ -61,7 +62,6 @@
       font-family: var(--font-family--default);
       font-weight: var(--font-weight--semibold);
       font-size: var(--font-size--5xsmall);
-      line-height: var(--line-height--nospace);
       text-decoration-color: transparent;
       text-decoration-line: underline;
       text-decoration-thickness: _rem(.1);

--- a/packages/compact-search/package.json
+++ b/packages/compact-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/compact-search",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Provides a compact search block.",
   "publishConfig": {
     "access": "public",

--- a/packages/compact-search/src/scss/styles.scss
+++ b/packages/compact-search/src/scss/styles.scss
@@ -32,6 +32,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    line-height: var(--line-height--nospace);
 
     &:is(:focus-visible > .compact-search__toggle) {
       outline: _rem(.2) solid var(--focus-indicator-color);
@@ -61,7 +62,6 @@
       font-family: var(--font-family--default);
       font-weight: var(--font-weight--semibold);
       font-size: var(--font-size--5xsmall);
-      line-height: var(--line-height--nospace);
       text-decoration-color: transparent;
       text-decoration-line: underline;
       text-decoration-thickness: _rem(.1);


### PR DESCRIPTION
Move the line height from the compact search and compact menu's label to the wrapper.