### PR TITLE
337 create white background variation of basic tile

### DIFF
--- a/packages/basic-tile/package.json
+++ b/packages/basic-tile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/basic-tile",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "description": "Provides a basic tile component.",
   "publishConfig": {
     "access": "public",

--- a/packages/basic-tile/package.json
+++ b/packages/basic-tile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/basic-tile",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "description": "Provides a basic tile component.",
   "publishConfig": {
     "access": "public",

--- a/packages/basic-tile/src/scss/styles.scss
+++ b/packages/basic-tile/src/scss/styles.scss
@@ -46,5 +46,9 @@
       background: var(--pa-link-light);
       color: var(--beaver-blue);
     }
+    
+    &:focus-visible {
+      outline-color: var(--pa-link);
+    }
   }
 }

--- a/packages/basic-tile/src/scss/styles.scss
+++ b/packages/basic-tile/src/scss/styles.scss
@@ -44,6 +44,7 @@
 
     &:hover, &:focus-visible {
       background: var(--pa-link-light);
+      color: var(--beaver-blue);
     }
   }
 }

--- a/packages/basic-tile/src/scss/styles.scss
+++ b/packages/basic-tile/src/scss/styles.scss
@@ -35,4 +35,15 @@
   &__secondary-label {
     font-weight: var(--font-weight--regular);
   }
+
+  &--light {
+    border: _rem(.1) solid var(--slate-light);
+    box-shadow: _rem(.1) _rem(.2) _rem(.3)  color-mix(in srgb, var(--nittany-navy) 25%, transparent);
+    background: var(--white);
+    color: var(--pa-link);
+
+    &:hover, &:focus-visible {
+      background: var(--pa-link-light);
+    }
+  }
 }

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~cta-tracking.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~cta-tracking.twig
@@ -1,5 +1,4 @@
 {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-  background_color: 'pa-link',
   url: '#',
   primary_label: 'Primary Label',
   secondary_label: 'Secondary Label',

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~cta-tracking.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~cta-tracking.twig
@@ -1,5 +1,5 @@
 {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-  background_color: 'primary-blue',
+  background_color: 'pa-link',
   url: '#',
   primary_label: 'Primary Label',
   secondary_label: 'Secondary Label',

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-grid.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-grid.twig
@@ -1,6 +1,6 @@
 {% set basic_tile %}
   {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-    background_color: 'primary-blue',
+    background_color: 'pa-link',
     url: '#',
     primary_label: 'Primary Label',
     secondary_label: 'Secondary Label'
@@ -9,7 +9,7 @@
 
 {% set basic_tile2 %}
   {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-    background_color: 'primary-blue',
+    background_color: 'pa-link',
     url: '#',
     primary_label: 'Primary Label that is very long that goes to two lines',
     secondary_label: 'Secondary Label'

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-grid.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-grid.twig
@@ -1,6 +1,5 @@
 {% set basic_tile %}
   {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-    background_color: 'pa-link',
     url: '#',
     primary_label: 'Primary Label',
     secondary_label: 'Secondary Label'
@@ -9,7 +8,6 @@
 
 {% set basic_tile2 %}
   {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-    background_color: 'pa-link',
     url: '#',
     primary_label: 'Primary Label that is very long that goes to two lines',
     secondary_label: 'Secondary Label'

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-no-primary.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-no-primary.twig
@@ -1,0 +1,7 @@
+
+{% include '@psu-ooe/basic-tile/basic-tile.twig' with {
+  background_color: 'pa-link',
+  url: '#',
+  primary_label: '',
+  secondary_label: 'Secondary Label'
+} only %}

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-no-primary.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-no-primary.twig
@@ -1,6 +1,4 @@
-
 {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-  background_color: 'pa-link',
   url: '#',
   primary_label: '',
   secondary_label: 'Secondary Label'

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-no-secondary.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-no-secondary.twig
@@ -1,6 +1,4 @@
-
 {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-  background_color: 'pa-link',
   url: '#',
   primary_label: 'Primary Label',
   secondary_label: ''

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-no-secondary.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default-no-secondary.twig
@@ -1,6 +1,7 @@
+
 {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-  background_color: 'primary-blue',
+  background_color: 'pa-link',
   url: '#',
   primary_label: 'Primary Label',
-  secondary_label: 'Secondary Label'
+  secondary_label: ''
 } only %}

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default.twig
@@ -1,7 +1,6 @@
-
 {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-  background_color: 'primary-blue',
+  background_color: 'pa-link',
   url: '#',
   primary_label: 'Primary Label',
-  secondary_label: ''
+  secondary_label: 'Secondary Label'
 } only %}

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~default.twig
@@ -1,5 +1,4 @@
 {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-  background_color: 'pa-link',
   url: '#',
   primary_label: 'Primary Label',
   secondary_label: 'Secondary Label'

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~light-grid.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~light-grid.twig
@@ -1,0 +1,21 @@
+{% set basic_tile %}
+  {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
+    background_color: 'light',
+    url: '#',
+    primary_label: 'Primary Label',
+    secondary_label: 'Secondary Label'
+  } only %}
+{% endset %}
+
+{% set basic_tile2 %}
+  {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
+    background_color: 'light',
+    url: '#',
+    primary_label: 'Primary Label that is very long that goes to two lines',
+    secondary_label: 'Secondary Label'
+  } only %}
+{% endset %}
+
+{% include '@psu-ooe/grid/grid.twig' with {
+  items: [basic_tile, basic_tile, basic_tile, basic_tile2],
+} only %}

--- a/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~light.twig
+++ b/packages/patternlab/source/patterns/molecules/basic-tile/basic-tile~light.twig
@@ -1,7 +1,6 @@
-
 {% include '@psu-ooe/basic-tile/basic-tile.twig' with {
-  background_color: 'primary-blue',
+  background_color: 'light',
   url: '#',
-  primary_label: '',
+  primary_label: 'Primary Label',
   secondary_label: 'Secondary Label'
 } only %}


### PR DESCRIPTION
# Description:
Create a light background variation for the basic tile component. I've also updated the background_color in patternlab to match 'pa-link' rather than primary-blue... even though the background_color for pa-link is the default & unused, technically. I just did not want to have to create a backward incompatible change for the other sites.

### Workfront Task Link
https://experience.adobe.com/#/@pennstateoutreach/so:pennstateoutreach-Production/workfront/task/67c1c67900041e53a22fa409a3241ae6/overview

### Adobe XD Link
https://www.figma.com/design/hkAGvhGfyEUdetoSMXG8Jn/Program-Pages?node-id=1-2&t=Zp0rtm4N9UebytdN-1

### Review environment Link
https://developers.outreach.psu.edu/337-create-white-background-variation-of-basic-tile/?p=viewall-molecules-basic-tile