### PR TITLE
Updating patternlab example for event spotlight

### DIFF
--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-ooe/patternlab",
-  "version": "2.0.46",
+  "version": "2.0.47",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/molecules/event-spotlight/event-spotlight.twig
+++ b/packages/patternlab/source/patterns/molecules/event-spotlight/event-spotlight.twig
@@ -21,6 +21,6 @@
   date: date,
   time: time,
   event_url: '#',
-  all_events_link: '#',
+  all_events_url: '#',
   all_events_title: 'View all events'
 } only %}


### PR DESCRIPTION
Description:
Updating the pattern lab example for event spotlight to reference "all_events_url" instead of "all_events_link"